### PR TITLE
Use HTTPS instead of SSH for the submodule reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "reference/antlr4"]
 	path = reference/antlr4
-	url = git@github.com:sharwell/antlr4.git
+	url = https://github.com/sharwell/antlr4.git
 	branch = optimized


### PR DESCRIPTION
This change eliminates the requirement that a user have an SSH key configured with a GitHub account in order to clone the repository.
