### PR TITLE
Enable strict null checking

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "target": "es2015",
     "noImplicitAny": true,
+    "strictNullChecks": true,
     "experimentalDecorators": true,
     "declaration": true,
     "preserveConstEnums": true,


### PR DESCRIPTION
Closes #14.   I think you'll like this Sam.

Note this version generates some errors (of the form `error TS2531: Object is possibly 'null'`) all of which seem valid to me.  If we adopt this, it seems like it could replace the `@NotNull` decorator.  (All errors are non-fatal, the tests still run.)

Seems like if we want to use this, the sooner the better.
