### PR TITLE
Run TSC prior to Mocha tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "prepublish": "tsc",
-    "test": "tsc && mocha"
+    "test": "tsc & mocha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Runs the tsc compiler before Mocha when the `npm test` command.   

This also  ensures the compiler is run on developer install, and prior to "publish" anything, which is why the "prepublish" life-cycle event exists in npm.

I haven't tested the interaction of this with the strict null checking, it _might_ decide not to run tests after compile errors, I'm not sure..., might take a minor tweak.
