### PR TITLE
Correct the initialization of Interval's cache

### DIFF
--- a/src/misc/Interval.ts
+++ b/src/misc/Interval.ts
@@ -41,7 +41,7 @@ export class Interval implements Equatable {
 		return Interval._INVALID;
 	}
 
-	private static cache: Interval[] = new Interval[INTERVAL_POOL_MAX_VALUE + 1];
+	private static cache: Interval[] = new Array<Interval>(INTERVAL_POOL_MAX_VALUE + 1);
 
 	/**
 	 * @param a The start of the interval


### PR DESCRIPTION
This blocks any tests that depend on module Interval.  Easy fix.   Because it's in static initialization, none of the tests run if any of them import Interval.
