### PR TITLE
Add a DefaultEqualityComparator that "works with any type"

### DIFF
--- a/src/misc/Array2DHashSet.ts
+++ b/src/misc/Array2DHashSet.ts
@@ -32,6 +32,7 @@
 // ConvertTo-TS run at 2016-10-03T02:09:41.7434086-07:00
 
 import * as assert from "assert";
+import { DefaultEqualityComparator } from './DefaultEqualityComparator';
 import {EqualityComparator} from './EqualityComparator';
 import {NotNull, Nullable, Override,SuppressWarnings} from './Stubs';
 import {Collection, asIterable, JavaIterable, JavaIterator, JavaCollection, JavaSet}  from './Stubs';
@@ -68,7 +69,7 @@ export class Array2DHashSet<T> implements JavaSet<T> {
 		 initialCapacity: number = INITAL_CAPACITY,
 		 initialBucketCapacity: number = INITAL_BUCKET_CAPACITY)  {
 
-		this.comparator = comparator || ObjectEqualityComparator.INSTANCE;
+		this.comparator = comparator || DefaultEqualityComparator.INSTANCE;
 		this.buckets = this.createBuckets(initialCapacity);
 		this.initialBucketCapacity = initialBucketCapacity;
 	}

--- a/src/misc/DefaultEqualityComparator.ts
+++ b/src/misc/DefaultEqualityComparator.ts
@@ -1,0 +1,81 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2012 Terence Parr
+ *  Copyright (c) 2012 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { EqualityComparator } from './EqualityComparator';
+import { Override, Equatable } from './Stubs';
+import { MurmurHash } from './MurmurHash';
+import { ObjectEqualityComparator } from './ObjectEqualityComparator';
+
+/**
+ * This default implementation of {@link EqualityComparator} uses object equality
+ * for comparisons by calling {@link Object#hashCode} and {@link Object#equals}.
+ *
+ * @author Sam Harwell
+ */
+export class DefaultEqualityComparator implements EqualityComparator<any> {
+	static INSTANCE: DefaultEqualityComparator = new DefaultEqualityComparator();
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>This implementation returns
+	 * {@code obj.}{@link Object#hashCode hashCode()}.</p>
+	 */
+	@Override
+	hashCode(obj: any): number {
+		if (obj == null) {
+			return 0;
+		} else if (typeof obj === 'string' || typeof obj === 'number') {
+			return MurmurHash.hashCode([obj]);
+		} else {
+			return ObjectEqualityComparator.INSTANCE.hashCode(<Equatable>obj);
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>This implementation relies on object equality. If both objects are
+	 * {@code null}, this method returns {@code true}. Otherwise if only
+	 * {@code a} is {@code null}, this method returns {@code false}. Otherwise,
+	 * this method returns the result of
+	 * {@code a.}{@link Object#equals equals}{@code (b)}.</p>
+	 */
+	@Override
+	equals(a: any, b: any): boolean {
+		if (a == null) {
+			return b == null;
+		} else if (typeof a === 'string' || typeof a === 'number') {
+			return a === b;
+		} else {
+			return ObjectEqualityComparator.INSTANCE.equals(<Equatable>a, <Equatable>b);
+		}
+	}
+}

--- a/src/misc/MurmurHash.ts
+++ b/src/misc/MurmurHash.ts
@@ -113,7 +113,7 @@ export namespace MurmurHash {
 	 * @param seed the seed for the MurmurHash algorithm
 	 * @return the hash code of the data
 	 */
-	export function hashCode<T extends number | string | Equatable>(data: T[], seed: number): number {
+	export function hashCode<T extends number | string | Equatable>(data: T[], seed: number = DEFAULT_SEED): number {
 		let hash: number =  initialize(seed);
 		for (let value of data) {
 			hash = update(hash, value);

--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -1,6 +1,7 @@
 // export * from './AbstractEqualityComparator';
 // export * from './Args';
 export * from './Array2DHashSet';
+export * from './DefaultEqualityComparator';
 // export * from './DoubleKeyMap';
 export * from './EqualityComparator';
 // export * from './FlexibleHashMap';


### PR DESCRIPTION
Fixes the issue with the `Array2DHashSet<T>` constructor.

Supersedes commit 7d2023b in #29.
