### PR TITLE
Import directly from named modules

### DIFF
--- a/src/CharStream.ts
+++ b/src/CharStream.ts
@@ -30,7 +30,7 @@
 
 // ConvertTo-TS run at 2016-10-04T11:26:50.0659297-07:00
 
-import {Interval} from './misc';
+import {Interval} from './misc/Interval';
 import {IntStream} from './IntStream';
 
 /** A source of characters for an ANTLR lexer. */

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -30,7 +30,7 @@
 
 // ConvertTo-TS run at 2016-10-04T11:26:51.7913318-07:00
 
-import { Token } from '.';
+import { Token } from './Token';
 
 /** A lexer is recognizer that draws input symbols from a character stream.
  *  lexer grammars result in a subclass of this object. A Lexer object

--- a/src/TokenStream.ts
+++ b/src/TokenStream.ts
@@ -30,7 +30,7 @@
 
 // ConvertTo-TS run at 2016-10-04T11:26:58.0433998-07:00
 
-import {Interval} from './misc';
+import {Interval} from './misc/Interval';
 import {IntStream} from './IntStream';
 import {RuleContext} from './RuleContext';
 import {Token} from './Token';

--- a/src/VocabularyImpl.ts
+++ b/src/VocabularyImpl.ts
@@ -31,8 +31,8 @@
 // ConvertTo-TS run at 2016-10-04T11:26:59.5829654-07:00
 
 import { NotNull, Nullable, Override } from './misc/Stubs';
-import { Token } from '.';
-import { Vocabulary } from '.';
+import { Token } from './Token';
+import { Vocabulary } from './Vocabulary';
 
 /**
  * This class provides a default implementation of the {@link Vocabulary}

--- a/src/atn/ATNState.ts
+++ b/src/atn/ATNState.ts
@@ -32,7 +32,7 @@
 
 import { ATN } from './ATN';
 import { ATNStateType } from './ATNStateType';
-import { IntervalSet } from '../misc';
+import { IntervalSet } from '../misc/IntervalSet';
 import { Override } from '../misc/Stubs';
 import { Transition } from './Transition';
 

--- a/src/atn/AbstractPredicateTransition.ts
+++ b/src/atn/AbstractPredicateTransition.ts
@@ -30,8 +30,8 @@
 
 // ConvertTo-TS run at 2016-10-04T11:26:24.6596177-07:00
 
-import { ATNState } from '.';
-import { Transition } from '.';
+import { ATNState } from './ATNState';
+import { Transition } from './Transition';
 
 /**
  *

--- a/src/atn/ActionTransition.ts
+++ b/src/atn/ActionTransition.ts
@@ -30,10 +30,10 @@
 
 // ConvertTo-TS run at 2016-10-04T11:26:24.7363448-07:00
 
-import { ATNState } from '.';
+import { ATNState } from './ATNState';
 import { Override, NotNull } from '../misc/Stubs';
-import { Transition } from '.';
-import { TransitionType } from '.';
+import { Transition } from './Transition';
+import { TransitionType } from './TransitionType';
 
 export class ActionTransition extends Transition {
 	ruleIndex: number;

--- a/src/atn/AtomTransition.ts
+++ b/src/atn/AtomTransition.ts
@@ -30,11 +30,11 @@
 
 // ConvertTo-TS run at 2016-10-04T11:26:27.6769122-07:00
 
-import { ATNState } from '.';
-import { IntervalSet } from '../misc';
+import { ATNState } from './ATNState';
+import { IntervalSet } from '../misc/IntervalSet';
 import { Override, NotNull } from '../misc/Stubs';
-import { Transition } from '.';
-import { TransitionType } from '.';
+import { Transition } from './Transition';
+import { TransitionType } from './TransitionType';
 
 /** TODO: make all transitions sets? no, should remove set edges */
 export class AtomTransition extends Transition {

--- a/src/atn/EpsilonTransition.ts
+++ b/src/atn/EpsilonTransition.ts
@@ -30,10 +30,10 @@
 
 // ConvertTo-TS run at 2016-10-04T11:26:28.6283213-07:00
 
-import { ATNState } from '.';
+import { ATNState } from './ATNState';
 import { Override, NotNull } from '../misc/Stubs';
-import { Transition } from '.';
-import { TransitionType } from '.';
+import { Transition } from './Transition';
+import { TransitionType } from './TransitionType';
 
 export class EpsilonTransition extends Transition {
 

--- a/src/atn/NotSetTransition.ts
+++ b/src/atn/NotSetTransition.ts
@@ -30,12 +30,12 @@
 
 // ConvertTo-TS run at 2016-10-04T11:26:30.8483617-07:00
 
-import { ATNState } from '.';
-import { IntervalSet } from '../misc';
+import { ATNState } from './ATNState';
+import { IntervalSet } from '../misc/IntervalSet';
 import { Override, NotNull, Nullable } from '../misc/Stubs';
-import { SetTransition } from '.';
-import { Transition } from '.';
-import { TransitionType } from '.';
+import { SetTransition } from './SetTransition';
+import { Transition } from './Transition';
+import { TransitionType } from './TransitionType';
 
 export class NotSetTransition extends SetTransition {
 	constructor(@NotNull target: ATNState, @Nullable set: IntervalSet) {

--- a/src/atn/RangeTransition.ts
+++ b/src/atn/RangeTransition.ts
@@ -30,11 +30,11 @@
 
 // ConvertTo-TS run at 2016-10-04T11:26:36.5959980-07:00
 
-import { ATNState } from '.';
-import { IntervalSet } from '../misc'
+import { ATNState } from './ATNState';
+import { IntervalSet } from '../misc/IntervalSet'
 import { Override, NotNull } from '../misc/Stubs';
-import { Transition } from '.';
-import { TransitionType } from '.';
+import { Transition } from './Transition';
+import { TransitionType } from './TransitionType';
 
 export class RangeTransition extends Transition {
 	from: number;

--- a/src/atn/RuleTransition.ts
+++ b/src/atn/RuleTransition.ts
@@ -30,11 +30,11 @@
 
 // ConvertTo-TS run at 2016-10-04T11:26:36.8294453-07:00
 
-import { ATNState } from '.';
+import { ATNState } from './ATNState';
 import { Override, NotNull } from '../misc/Stubs';
-import { RuleStartState } from '.';
-import { Transition } from '.';
-import { TransitionType } from '.';
+import { RuleStartState } from './RuleStartState';
+import { Transition } from './Transition';
+import { TransitionType } from './TransitionType';
 
 /** */
 export class RuleTransition extends Transition {

--- a/src/atn/SetTransition.ts
+++ b/src/atn/SetTransition.ts
@@ -30,12 +30,12 @@
 
 // ConvertTo-TS run at 2016-10-04T11:26:37.3060135-07:00
 
-import { ATNState } from '.';
-import { IntervalSet } from '../misc';
+import { ATNState } from './ATNState';
+import { IntervalSet } from '../misc/IntervalSet';
 import { Override, NotNull, Nullable } from '../misc/Stubs';
-import { Token } from '..';
-import { Transition } from '.';
-import { TransitionType } from '.';
+import { Token } from '../Token';
+import { Transition } from './Transition';
+import { TransitionType } from './TransitionType';
 
 /** A transition containing a set of values. */
 export class SetTransition extends Transition {

--- a/src/atn/Transition.ts
+++ b/src/atn/Transition.ts
@@ -30,10 +30,10 @@
 
 // ConvertTo-TS run at 2016-10-04T11:26:37.8530496-07:00
 
-import { ATNState } from '.';
-import { IntervalSet } from '../misc';
+import { ATNState } from './ATNState';
+import { IntervalSet } from '../misc/IntervalSet';
 import { NotNull, Nullable } from '../misc/Stubs';
-import { TransitionType } from '.';
+import { TransitionType } from './TransitionType';
 
 /** An ATN transition between any two ATN states.  Subclasses define
  *  atom, set, epsilon, action, predicate, rule transitions.

--- a/src/atn/WildcardTransition.ts
+++ b/src/atn/WildcardTransition.ts
@@ -30,10 +30,10 @@
 
 // ConvertTo-TS run at 2016-10-04T11:26:37.9456839-07:00
 
-import { ATNState } from '.';
+import { ATNState } from './ATNState';
 import { Override, NotNull } from '../misc/Stubs';
-import { Transition } from '.';
-import { TransitionType } from '.';
+import { Transition } from './Transition';
+import { TransitionType } from './TransitionType';
 
 export class WildcardTransition extends Transition {
 	constructor(@NotNull target: ATNState) {

--- a/src/misc/ArrayEqualityComparator.ts
+++ b/src/misc/ArrayEqualityComparator.ts
@@ -31,8 +31,8 @@
 // ConvertTo-TS run at 2016-10-03T02:09:42.2127260-07:00
 import { EqualityComparator } from './EqualityComparator';
 import { Override, Equatable } from './Stubs';
-import { MurmurHash } from '.';
-import { ObjectEqualityComparator } from '.';
+import { MurmurHash } from './MurmurHash';
+import { ObjectEqualityComparator } from './ObjectEqualityComparator';
 
 /**
  * This default implementation of {@link EqualityComparator} uses object equality

--- a/src/misc/IntervalSet.ts
+++ b/src/misc/IntervalSet.ts
@@ -30,14 +30,14 @@
 
 // ConvertTo-TS run at 2016-10-04T11:26:40.8683480-07:00
 
-import { ArrayEqualityComparator } from '.';
-import { Interval } from '.';
-import { IntSet } from '.';
-import { Lexer } from '..';
-import { MurmurHash } from '.';
+import { ArrayEqualityComparator } from './ArrayEqualityComparator';
+import { Interval } from './Interval';
+import { IntSet } from './IntSet';
+import { Lexer } from '../Lexer';
+import { MurmurHash } from './MurmurHash';
 import { Override, NotNull, Nullable } from './Stubs';
-import { Token } from '..';
-import { Vocabulary } from '..';
+import { Token } from '../Token';
+import { Vocabulary } from '../Vocabulary';
 
 /**
  * This class implements the {@link IntSet} backed by a sorted array of

--- a/src/tree/SyntaxTree.ts
+++ b/src/tree/SyntaxTree.ts
@@ -31,7 +31,7 @@
 // ConvertTo-TS run at 2016-10-04T11:26:47.9953174-07:00
 
 import {Tree} from './Tree';
-import {Interval} from '../misc';
+import {Interval} from '../misc/Interval';
 
 /** A tree that knows about an interval in a token stream
  *  is some kind of syntax tree. Subinterfaces distinguish


### PR DESCRIPTION
I ran into some trouble with importing from an **index.ts** with some module loading settings. Importing exactly what we need seems to be more reliable and perform better as well.
