### PR TITLE
Fix handling of null and undefined in EdgeMap

### DIFF
--- a/src/dfa/AbstractEdgeMap.ts
+++ b/src/dfa/AbstractEdgeMap.ts
@@ -56,9 +56,8 @@ export abstract class AbstractEdgeMap<T> implements EdgeMap<T> {
 	// @Override
 	abstract containsKey(key: number): boolean;
 
-	// @Nullable
 	// @Override
-	abstract get(key: number): T;
+	abstract get(key: number): T | undefined;
 
 	// @NotNull
 	// @Override

--- a/src/dfa/ArrayEdgeMap.ts
+++ b/src/dfa/ArrayEdgeMap.ts
@@ -41,7 +41,7 @@ import * as assert from 'assert';
  * @author Sam Harwell
  */
 export class ArrayEdgeMap<T> extends AbstractEdgeMap<T> {
-	private arrayData: T[];
+	private arrayData: (T | undefined)[];
 	private _size: number;
 
 	constructor(minIndex: number, maxIndex: number) {
@@ -62,22 +62,22 @@ export class ArrayEdgeMap<T> extends AbstractEdgeMap<T> {
 
 	@Override
 	containsKey(key: number): boolean {
-		return this.get(key) != null;
+		return !!this.get(key);
 	}
 
 	@Override
-	get(key: number): T {
+	get(key: number): T | undefined {
 		if (key < this.minIndex || key > this.maxIndex) {
-			return null;
+			return undefined;
 		}
 
 		return this.arrayData[key - this.minIndex];
 	}
 
 	@Override
-	put(key: number, value: T): ArrayEdgeMap<T> {
+	put(key: number, value: T | undefined): ArrayEdgeMap<T> {
 		if (key >= this.minIndex && key <= this.maxIndex) {
-			let existing: T = this.arrayData[key - this.minIndex];
+			let existing: T | undefined = this.arrayData[key - this.minIndex];
 			this.arrayData[key - this.minIndex] = value;
 			if (existing == null && value != null) {
 				this._size++;
@@ -91,7 +91,7 @@ export class ArrayEdgeMap<T> extends AbstractEdgeMap<T> {
 
 	@Override
 	remove(key: number): ArrayEdgeMap<T> {
-		return this.put(key, null);
+		return this.put(key, undefined);
 	}
 
 	@Override
@@ -142,7 +142,7 @@ export class ArrayEdgeMap<T> extends AbstractEdgeMap<T> {
 
 		let result: Map<number, T> = new Map<number, T>();
 		for (let i = 0; i < this.arrayData.length; i++) {
-			let element: T = this.arrayData[i];
+			let element: T | undefined = this.arrayData[i];
 			if (element == null) {
 				continue;
 			}
@@ -159,10 +159,10 @@ export class ArrayEdgeMap<T> extends AbstractEdgeMap<T> {
 }
 
 class EntrySet<T> implements Iterable<{ key: number, value: T }> {
-	private readonly arrayData: T[];
+	private readonly arrayData: (T | undefined)[];
 	private readonly minIndex: number;
 
-	constructor(arrayData: T[], minIndex: number) {
+	constructor(arrayData: (T | undefined)[], minIndex: number) {
 		this.arrayData = arrayData;
 		this.minIndex = minIndex;
 	}
@@ -173,11 +173,11 @@ class EntrySet<T> implements Iterable<{ key: number, value: T }> {
 }
 
 class EntrySetIterator<T> implements Iterator<{ key: number, value: T }> {
-	private readonly arrayData: T[];
+	private readonly arrayData: (T | undefined)[];
 	private readonly minIndex: number;
 	private index: number;
 
-	constructor(arrayData: T[], minIndex: number) {
+	constructor(arrayData: (T | undefined)[], minIndex: number) {
 		this.arrayData = arrayData;
 		this.minIndex = minIndex;
 		this.index = 0;
@@ -193,7 +193,7 @@ class EntrySetIterator<T> implements Iterator<{ key: number, value: T }> {
 		let reachedEnd = this.index >= this.arrayData.length;
 		let result = { done: reachedEnd, value: reachedEnd ? undefined : { key: this.index + this.minIndex, value: this.arrayData[this.index] } };
 		this.index++;
-		return result;
+		return result as any as IteratorResult<{ key: number, value: T }>;
 	}
 
 	return?(value?: any): IteratorResult<{ key: number, value: T }> {

--- a/src/dfa/EdgeMap.ts
+++ b/src/dfa/EdgeMap.ts
@@ -40,11 +40,10 @@ export interface EdgeMap<T> {
 
 	containsKey(key: number): boolean;
 
-	// @Nullable
-	get(key: number): T;
+	get(key: number): T | undefined;
 
 	// @NotNull
-	put(key: number, /*@Nullable*/ value: T): EdgeMap<T>;
+	put(key: number, value: T): EdgeMap<T>;
 
 	// @NotNull
 	remove(key: number): EdgeMap<T>;

--- a/src/dfa/EmptyEdgeMap.ts
+++ b/src/dfa/EmptyEdgeMap.ts
@@ -78,8 +78,8 @@ export class EmptyEdgeMap<T> extends AbstractEdgeMap<T> {
 	}
 
 	@Override
-	get(key: number): T {
-		return null;
+	get(key: number): undefined {
+		return undefined;
 	}
 
 	@Override

--- a/src/dfa/SingletonEdgeMap.ts
+++ b/src/dfa/SingletonEdgeMap.ts
@@ -40,7 +40,7 @@ import { SparseEdgeMap } from './SparseEdgeMap';
 export class SingletonEdgeMap<T> extends AbstractEdgeMap<T> {
 
 	private key: number; 
-	private value: T; 
+	private value: T | undefined;
 
 	 constructor(minIndex: number, maxIndex: number, key: number, value: T)  {
 		super(minIndex, maxIndex);
@@ -49,7 +49,7 @@ export class SingletonEdgeMap<T> extends AbstractEdgeMap<T> {
 			this.value = value;
 		} else {
 			this.key = 0;
-			this.value = null;
+			this.value = undefined;
 		}
 	}
 
@@ -57,7 +57,7 @@ export class SingletonEdgeMap<T> extends AbstractEdgeMap<T> {
 		return this.key;
 	}
 
-	getValue(): T {
+	getValue(): T | undefined {
 		return this.value;
 	}
 
@@ -77,12 +77,12 @@ export class SingletonEdgeMap<T> extends AbstractEdgeMap<T> {
 	}
 
 	@Override
-	get(key: number): T {
+	get(key: number): T | undefined {
 		if (key === this.key) {
 			return this.value;
 		}
 
-		return null;
+		return undefined;
 	}
 
 	@Override
@@ -132,10 +132,11 @@ export class SingletonEdgeMap<T> extends AbstractEdgeMap<T> {
 
 	@Override
 	entrySet(): Iterable<{ key: number, value: T }> {
-		if (this.isEmpty()) {
+		let value: T | undefined = this.value;
+		if (!value) {
 			return [];
-		} else {
-			return [{ key: this.key, value: this.value }];
 		}
+
+		return [{ key: this.key, value: value }];
 	}
 }

--- a/src/dfa/SparseEdgeMap.ts
+++ b/src/dfa/SparseEdgeMap.ts
@@ -88,17 +88,17 @@ export class SparseEdgeMap<T> extends AbstractEdgeMap<T> {
 
 	@Override
 	containsKey(key: number): boolean {
-		return this.get(key) != null;
+		return !!this.get(key);
 	}
 
 	@Override
-	get(key: number): T {
+	get(key: number): T | undefined {
 		// Special property of this collection: values are only even added to
 		// the end, else a new object is returned from put(). Therefore no lock
 		// is required in this method.
 		let index: number = Arrays.binarySearch(this.keys, 0, this.size(), key);
 		if (index < 0) {
-			return null;
+			return undefined;
 		}
 
 		return this.values[index];
@@ -221,7 +221,7 @@ class EntrySetIterator<T> implements Iterator<{ key: number, value: T }> {
 
 	next(value?: any): IteratorResult<{ key: number, value: T }> {
 		if (this.index >= this.values.length) {
-			return { done: true, value: undefined };
+			return { done: true, value: undefined } as any as IteratorResult<{ key: number, value: T }> ;
 		}
 
 		let currentIndex = this.index++;


### PR DESCRIPTION
This pull request addresses cases where `undefined` and `null` are being used in `EdgeMap<T>` without being part of type signatures.

:memo: Strict null checks are currently disabled, but we're working to change that. See #26.
