### PR TITLE
Add undefined to the Transition.label() type signature

### DIFF
--- a/src/atn/Transition.ts
+++ b/src/atn/Transition.ts
@@ -104,9 +104,8 @@ export abstract class Transition {
 		return false;
 	}
 
-	@Nullable
-	label(): IntervalSet {
-		return null;
+	label(): IntervalSet | undefined {
+		return undefined;
 	}
 
 	abstract matches(symbol: number, minVocabSymbol: number, maxVocabSymbol: number): boolean;


### PR DESCRIPTION
Previously this method was relying on the `@Nullable` decorator to convey this information. By including it in the type signature, the compiler can analyze its usage.

📝 Strict null checks are currently disabled, but we're working to change that. See #26.
