### PR TITLE
Implement PredictionContext.toStrings

### DIFF
--- a/CONVERSION.md
+++ b/CONVERSION.md
@@ -110,8 +110,8 @@ in individual files can be removed and the antlr4 submodule commit will track th
 * [ ] atn\PredicateTransition.java
 * [x] atn\PredictionContext.java
   * [x] PredictionContext.fromRuleContext
-  * [ ] PredictionContext.toString
-  * [ ] PredictionContext.toStrings
+  * [x] ~~PredictionContext.toString~~ (Doesn't actually exist in the Java target)
+  * [x] PredictionContext.toStrings
 * [x] atn\PredictionContextCache.java
 * [ ] atn\PredictionMode.java
 * [ ] atn\ProfilingATNSimulator.java


### PR DESCRIPTION
This commit also removes the commented-out method `PredictionContext.toString`, as that method does not actually exist in the Java target either.
