### PR TITLE
Fix the signatures of getParent()

### DIFF
--- a/src/tree/RuleNode.ts
+++ b/src/tree/RuleNode.ts
@@ -40,7 +40,7 @@ export abstract class RuleNode implements ParseTree {
 	abstract getRuleContext(): RuleContext;
 
 	//@Override
-	abstract getParent(): RuleContext;
+	abstract getParent(): RuleNode | undefined;
 
 	abstract getChild(i: number): ParseTree;
 

--- a/src/tree/TerminalNode.ts
+++ b/src/tree/TerminalNode.ts
@@ -40,7 +40,7 @@ import { Token } from '../Token';
 
 export class TerminalNode implements ParseTree  {
 	symbol: Token;
-	parent: RuleNode;
+	parent: RuleNode | undefined;
 
 	constructor(symbol: Token) {
 		this.symbol = symbol;
@@ -57,7 +57,7 @@ export class TerminalNode implements ParseTree  {
 	}
 
 	@Override
-	getParent(): RuleNode {
+	getParent(): RuleNode | undefined {
 		return this.parent;
 	}
 


### PR DESCRIPTION
During review of #105, I noticed that the signature of `RuleNode.getParent()` referenced `RuleContext` instead of `RuleNode`. This pull request corrects that, and also updates the signature to allow `undefined` (which the super interfaces already do).
