### PR TITLE
Use findIndex instead of Arrays.indexOf

### DIFF
--- a/src/atn/ATNDeserializer.ts
+++ b/src/atn/ATNDeserializer.ts
@@ -31,7 +31,6 @@
 // ConvertTo-TS run at 2016-10-04T11:26:25.9683447-07:00
 
 import { ActionTransition } from './ActionTransition';
-import { Arrays } from '../misc/Arrays';
 import { ATN } from './ATN';
 import { ATNDeserializationOptions } from './ATNDeserializationOptions';
 import { ATNState } from './ATNState';
@@ -147,12 +146,12 @@ export class ATNDeserializer {
 	 * introduced; otherwise, {@code false}.
 	 */
 	protected isFeatureSupported(feature: UUID, actualUuid: UUID): boolean {
-		let featureIndex: number = Arrays.indexOf(ATNDeserializer.SUPPORTED_UUIDS, feature);
+		let featureIndex: number = ATNDeserializer.SUPPORTED_UUIDS.findIndex(e => e.equals(feature));
 		if (featureIndex < 0) {
 			return false;
 		}
 
-		return Arrays.indexOf(ATNDeserializer.SUPPORTED_UUIDS, actualUuid) >= featureIndex;
+		return ATNDeserializer.SUPPORTED_UUIDS.findIndex(e => e.equals(actualUuid)) >= featureIndex;
 	}
 
 	deserialize(@NotNull data: Uint16Array): ATN {
@@ -171,7 +170,7 @@ export class ATNDeserializer {
 
 		let uuid: UUID = ATNDeserializer.toUUID(data, p);
 		p += 8;
-		if (Arrays.indexOf(ATNDeserializer.SUPPORTED_UUIDS, uuid) >= 0) {
+		if (ATNDeserializer.SUPPORTED_UUIDS.findIndex(e => e.equals(uuid)) >= 0) {
 			let reason = `Could not deserialize ATN with UUID ${uuid} (expected ${ATNDeserializer.SERIALIZED_UUID} or a legacy UUID).`;
 			throw new Error(reason);
 		}

--- a/src/misc/Arrays.ts
+++ b/src/misc/Arrays.ts
@@ -26,10 +26,6 @@
  *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { EqualityComparator } from './EqualityComparator';
-import { Equatable } from './Stubs';
-import { ObjectEqualityComparator } from './ObjectEqualityComparator';
-
 export namespace Arrays {
 	/**
 	 * Searches the specified array of numbers for the specified value using the binary search algorithm. The array must
@@ -65,23 +61,6 @@ export namespace Arrays {
 
 		// key not found.
 		return -(low + 1);
-	}
-
-	export function indexOf<T extends Equatable>(array: ArrayLike<T>, obj: T): number;
-	export function indexOf<T>(array: ArrayLike<T>, obj: T, comparator: EqualityComparator<T>): number;
-	export function indexOf<T>(array: ArrayLike<T>, obj: T, comparator?: EqualityComparator<T>): number {
-		if (comparator == null) {
-			// This is safe because comparator can only be optional if T extends Equatable
-			comparator = ObjectEqualityComparator.INSTANCE as any as EqualityComparator<T>;
-		}
-
-		for (let i = 0; i < array.length; i++) {
-			if (comparator.equals(array[i], obj)) {
-				return i;
-			}
-		}
-
-		return -1;
 	}
 
 	export function toString<T>(array: ArrayLike<T>) {


### PR DESCRIPTION
Improves clarity for JavaScript users, as requested in #132.
