### PR TITLE
Lazily initialize the _ATN field

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
@@ -975,8 +975,14 @@ SerializedATN(model, className={<if(lexer)><lexer.name><else><parser.name><endif
 <! only one segment, can be inlined !>
 public static readonly _serializedATN: string =
 	"<model.serialized; wrap={"+<\n><\t>"}>";
-public static readonly _ATN: ATN =
-	new ATNDeserializer().deserialize(Utils.toCharArray(<className>._serializedATN));
+public static __ATN: ATN;
+public static get _ATN(): ATN {
+	if (!<className>.__ATN) {
+		<className>.__ATN = new ATNDeserializer().deserialize(Utils.toCharArray(<className>._serializedATN));
+	}
+
+	return <className>.__ATN;
+}
 <!static {
 	org.antlr.v4.tool.DOTGenerator dot = new org.antlr.v4.tool.DOTGenerator(null);
 	System.out.println(dot.getDOT(_ATN.decisionToState.get(0), ruleNames, false));


### PR DESCRIPTION
This is part of the work to avoid circular dependencies during initialization.
