### PR TITLE
Trim final newline in DFASerializer result

### DIFF
--- a/src/dfa/DFASerializer.ts
+++ b/src/dfa/DFASerializer.ts
@@ -119,8 +119,13 @@ export class DFASerializer {
 				}
 			}
 		}
+
 		let output: string =  buf;
-		if ( output.length===0 ) return "";
+		if (output.endsWith("\n")) {
+			// trim the final newline
+			output = output.substr(0, output.length - 1);
+		}
+
 		//return Utils.sortLinesInString(output);
 		return output;
 	}


### PR DESCRIPTION
This change overcomes most of a limitation in the testing framework, where
`console.log` always appends a new line character.
