### PR TITLE
Publish on npmjs.com

### DIFF
--- a/tool/README.md
+++ b/tool/README.md
@@ -4,9 +4,8 @@
 >
 > Licensed under the BSD-3-clause license. See [LICENSE](./LICENSE) file in the project root for license information.
 
-:warning: This is pre-release software - Stability 0.
-<div class="api_stability api_stability_1">Stability 1 - Experimental.  <br> This feature was introduced recently, and may change
-or be removed in the future. </div>
+<div class="api_stability api_stability_1">Stability 1 - Experimental. :warning:<br>
+This feature was introduced recently, and may change or be removed in the future. </div>
 
 #Installation
 

--- a/tool/package.json
+++ b/tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antlr4ts-cli",
-  "version": "0.2.1-0",
+  "version": "0.2.2-0",
   "preferGlobal": true,
   "description": "Antlr4 command line tool for TypeScript",
   "files": [


### PR DESCRIPTION
I used `npm -version minor` to update the antlr4ts-cli version number (to 0.2.0).   Then I used `npm publish` to create an entry on the npm web site.   Check it out: https://www.npmjs.com/package/antlr4ts-cli.

@sharwell there are probably steps we should take when this happens you understand better than I.   E.g. a tag in git.    I also realize that with the MVN build running on my machine, the JRE support isn't as broad as it should be.    Were you planning on "publishing" from appveyor?  

I experimented some with updates, pre-release versions, and "unpublish".   If you create an account for yourself on npmjs.com , we can share administrator access.   I don't think we need an "organization" in the short term.
