### PR TITLE
Integrate TypeDoc into build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ src/tree/xpath/XPathLexer.tokens
 src/tree/xpath/XPathLexer.ts
 /target/
 /tool/target/
+doc/
 
 # Visual Studio build output and per-user files
 obj/

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "scripts": {
     "antlr4ts": "antlr4ts src/tree/xpath/XPathLexer.g4 -DbaseImportPath=../.. -o src/tree/xpath",
     "tsc": "tsc",
-    "prepublish": "npm i tool && npm run antlr4ts && npm run tsc",
+    "prepublish": "npm i tool && npm run antlr4ts && npm run tsc && npm run typedoc",
     "pretest": "npm run prepublish",
-
     "test": "mocha",
     "precover": "npm run prepubish",
     "cover": "istanbul cover node_modules/mocha/bin/_mocha",
     "postcover": "istanbul report",
-    "dev-test-watch": "mocha-typescript-watch"
+    "dev-test-watch": "mocha-typescript-watch",
+    "typedoc": "typedoc --ignoreCompilerErrors --out doc src --name antlr4ts"
   },
   "repository": {
     "type": "git",
@@ -36,6 +36,7 @@
     "mocha": "^3.1.0",
     "mocha-typescript": "^1.0.10",
     "source-map-support": "^0.4.3",
+    "typedoc": "^0.5.1",
     "typescript": "^2.0.3"
   },
   "dependencies": {}


### PR DESCRIPTION
Looks like the `TypeDoc` project has caught-up with TypeScript, at least enough to get basic functionality running.   I've added a developer dependency on it and running it to the `prepublish` step   There are several errors flagged during its running mostly about module `assert`.      These seem due to TypeStrong/typedoc#315.

The output goes into a "doc" directory, and should automatically benefit from the work you've been doing on the README.md file.   I've avoided changing the README to make things look better as you said you were splitting it up.

Docs on TypeDoc at http://typedoc.org/guides/

Fixes #44, at least partially.