### PR TITLE
Ignore TypeScript files under the tool directory

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
   },
   "exclude": [
     "node_modules",
-    "target"
+    "target",
+    "tool"
   ]
 }


### PR DESCRIPTION
Prior to this change, temporary test files left in the **tool/target** directory could cause the TypeScript compile to fail.