### PR TITLE
Fix merge key handling in ATNConfigSet.canMerge

### DIFF
--- a/src/atn/ATNConfigSet.ts
+++ b/src/atn/ATNConfigSet.ts
@@ -356,7 +356,7 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 			return false;
 		}
 
-		if (leftKey != this.getKey(right)) {
+		if (leftKey.alt !== right.getAlt()) {
 			return false;
 		}
 


### PR DESCRIPTION
The previous code was preventing the parser from merging `ATNConfig` instances in an `ATNConfigSet`, which is very inefficient at runtime.

The performance improvement varies by grammar; on **JavaLR.g4** the parse time for **java.\*** dropped from over 2 hours (didn't complete) to 18 seconds (*at least* 400x faster) when parsing **java.\***, and on **Java.g4** it now completes parsing in a reasonable time (23 seconds locally) where previously we never saw it complete even when limited to the **java.lang.\*** subset of inputs.

:memo: I'll fill in the blanks when the test completes and tells me the time. **Update:** the before time is at least ~~35 minutes~~ 2 hours (test isn't complete yet). **Update again:** I gave up after 2 hours and cancelled it.