### PR TITLE
Array2DHashSet fixes

### DIFF
--- a/src/misc/Array2DHashSet.ts
+++ b/src/misc/Array2DHashSet.ts
@@ -384,6 +384,7 @@ export class Array2DHashSet<T> implements JavaSet<T> {
 	clear(): void {
 		this.buckets = this.createBuckets(INITAL_CAPACITY);
 		this.n = 0;
+		this.threshold = Math.floor(INITAL_CAPACITY * LOAD_FACTOR);
 	}
 
 	@Override


### PR DESCRIPTION
* Remove unused field `currentPrime`
* Set `threshold` when calling `clear()` (see antlr/antlr4#1318)