### PR TITLE
Mocha runtime tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,7 @@ jspm_packages/
 # Build products
 /src/tree/xpath/XPathLexer.tokens
 /src/tree/xpath/XPathLexer.ts
-/benchmark/gen/
-/test/tool/gen/
+gen/
 /target/
 /tool/target/
 doc/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,13 +34,6 @@ subset of the TypeScript runtime's functionality.
 npm test
 ```
 
-The second set of tests comes from the ANTLR 4 runtime test suite, which provides functional tests of a much larger
-set of functionality. The runtime test suite can be generated and executed using the following command.
-
-```
-mvn -f tool/pom.xml test
-```
-
 ### Performance testing
 
 To run the benchmark suite with profiling enabled, run this command:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,10 @@ subset of the TypeScript runtime's functionality.
 npm test
 ```
 
+The second set of tests comes from the ANTLR 4 runtime test suite, which provides functional tests of a much larger set
+of functionality. The runtime test suite is generated and compiled as part of the `npm install` command, and executed
+using the previously-described `npm test` command.
+
 ### Performance testing
 
 To run the benchmark suite with profiling enabled, run this command:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ build_script:
 - npm install
 test_script:
 - npm test
-- mvn -B -f tool/pom.xml -Dgpg.skip=true -Psonatype-oss-release test
+# - mvn -B -f tool/pom.xml -Dgpg.skip=true -Psonatype-oss-release test
 cache:
 - node_modules -> **\package.json
 - C:\Users\appveyor\.m2 -> **\pom.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ build_script:
 - npm install
 test_script:
 - npm test
-# - mvn -B -f tool/pom.xml -Dgpg.skip=true -Psonatype-oss-release test
 cache:
 - node_modules -> **\package.json
 - C:\Users\appveyor\.m2 -> **\pom.xml

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "mocha": "^3.1.0",
     "mocha-typescript": "^1.0.10",
     "source-map-support": "^0.4.3",
+    "std-mocks": "^1.0.1",
     "typedoc": "^0.5.1",
     "typescript": "^2.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antlr4ts-root",
-  "version": "0.1.1-SNAPSHOT",
+  "version": "0.4.0-SNAPSHOT",
   "description": "Root project for ANTLR 4 runtime for Typescript",
   "private": true,
   "main": "index.js",
@@ -18,7 +18,7 @@
     "antlr4ts-benchmark-std-atn": "antlr4ts -visitor -Xforce-atn benchmark/Java.g4 -DbaseImportPath=../../../src -o benchmark/gen/std-atn",
     "antlr4ts-benchmark-lr": "antlr4ts -visitor benchmark/JavaLR.g4 -DbaseImportPath=../../../src -o benchmark/gen/lr",
     "antlr4ts-benchmark-lr-atn": "antlr4ts -visitor -Xforce-atn benchmark/JavaLR.g4 -DbaseImportPath=../../../src -o benchmark/gen/lr-atn",
-    "tsc": "tsc",
+    "tsc": "tsc && cd test/runtime && tsc",
     "test": "mocha",
     "cover": "istanbul cover node_modules/mocha/bin/_mocha",
     "postcover": "istanbul report",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "prepublish": "npm run buildtool && npm link antlr4ts-cli && npm run antlr4ts && npm run tsc && npm link target/src",
+    "prepublish": "npm run buildtool && npm link antlr4ts-cli && npm run antlr4ts && npm run tsc && npm link target/src && npm run buildrts",
     "unlink": "npm unlink antlr4ts && npm unlink target/src && npm unlink antlr4ts-cli && npm run unlinkruntime && npm run unlinktool",
     "unlinkruntime": "cd target/src && npm unlink",
     "buildtool": "cd tool && npm link",
@@ -18,7 +18,8 @@
     "antlr4ts-benchmark-std-atn": "antlr4ts -visitor -Xforce-atn benchmark/Java.g4 -DbaseImportPath=../../../src -o benchmark/gen/std-atn",
     "antlr4ts-benchmark-lr": "antlr4ts -visitor benchmark/JavaLR.g4 -DbaseImportPath=../../../src -o benchmark/gen/lr",
     "antlr4ts-benchmark-lr-atn": "antlr4ts -visitor -Xforce-atn benchmark/JavaLR.g4 -DbaseImportPath=../../../src -o benchmark/gen/lr-atn",
-    "tsc": "tsc && cd test/runtime && tsc",
+    "tsc": "tsc",
+    "buildrts": "cd test/runtime && tsc",
     "test": "mocha",
     "cover": "istanbul cover node_modules/mocha/bin/_mocha",
     "postcover": "istanbul report",

--- a/target/src/package.json
+++ b/target/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antlr4ts",
-  "version": "0.1.1-SNAPSHOT",
+  "version": "0.4.0-SNAPSHOT",
   "description": "Antlr4 runtime for JavaScript written in Typescript",
   "main": "index.js",
   "scripts": {

--- a/test/TestExpectStream.ts
+++ b/test/TestExpectStream.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright 2016 Terence Parr, Sam Harwell, and Burt Harris
+ * All rights reserved.
+ * Licensed under the BSD-3-clause license. See LICENSE file in the project root for license information.
+ */
+
+import * as es from './runtime/ExpectStream';
+
+describe("expectConsole()", () => {
+	it('should capture console.log()', () => {
+		es.expectConsole( "Testing 1,2,3\nbye\n", "", ()=> {
+			console.log("Testing 1,2,3");
+			console.log("bye");
+		})
+	});
+	it('should capture console.error()', ()=> {
+		es.expectConsole( "", "pseudo-error\n", ()=>{
+			console.error("pseudo-error");
+		});
+	});
+})

--- a/test/runtime/BaseTest.ts
+++ b/test/runtime/BaseTest.ts
@@ -1,0 +1,46 @@
+/*!
+ * Copyright 2016 Terence Parr, Sam Harwell, and Burt Harris
+ * All rights reserved.
+ * Licensed under the BSD-3-clause license. See LICENSE file in the project root for license information.
+ */
+
+import * as assert from 'assert';
+import { ANTLRInputStream } from 'antlr4ts/ANTLRInputStream';
+import { CharStream } from 'antlr4ts/CharStream';
+import { CommonTokenStream } from 'antlr4ts/CommonTokenStream';
+import { Lexer } from 'antlr4ts/Lexer';
+const stdMocks = require('std-mocks');
+
+function expectConsole( output: string, errors: string, testFunction: ()=> void ) {
+	try {
+		stdMocks.use();
+		testFunction();
+	} finally {
+		stdMocks.restore();
+		let streams = stdMocks.flush();
+		assert.equal( streams.stdout.join(''), output);
+		assert.equal( streams.stderr.join(''), errors);
+	}
+}
+
+export interface LexerTestOptions {
+	testName: string;
+	lexer: new(s:CharStream) => Lexer;
+	input: string;
+	expectedOutput: string;
+	expectedErrors: string;
+	showDFA?: boolean;
+}
+
+export function lexerTest(options: LexerTestOptions) {
+	const inputStream: CharStream = new ANTLRInputStream(options.input);
+	const lex = new options.lexer(inputStream);
+	const tokens = new CommonTokenStream(lex);
+	expectConsole( options.expectedOutput, options.expectedErrors, ()=> {
+		tokens.fill();
+		tokens.getTokens().forEach(t =>console.log(t.toString()));
+		if (options.showDFA)
+			process.stdout.write(lex.getInterpreter().getDFA(Lexer.DEFAULT_MODE).toLexerString());
+	});
+}
+

--- a/test/runtime/BaseTest.ts
+++ b/test/runtime/BaseTest.ts
@@ -73,8 +73,9 @@ export function lexerTest(options: LexerTestOptions) {
 	expectConsole( options.expectedOutput, options.expectedErrors, ()=> {
 		tokens.fill();
 		tokens.getTokens().forEach(t =>console.log(t.toString()));
-		if (options.showDFA)
+		if (options.showDFA) {
 			process.stdout.write(lex.getInterpreter().getDFA(Lexer.DEFAULT_MODE).toLexerString());
+		}
 	});
 }
 

--- a/test/runtime/ExpectStream.ts
+++ b/test/runtime/ExpectStream.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright 2016 Terence Parr, Sam Harwell, and Burt Harris
+ * All rights reserved.
+ * Licensed under the BSD-3-clause license. See LICENSE file in the project root for license information.
+ */
+
+import * as assert from 'assert';
+const stdMocks = require('std-mocks');
+
+export function expectConsole( output: string, errors: string, during: ()=> void ) {
+	try {
+		stdMocks.use();
+		during();
+	} finally {
+		stdMocks.restore();
+		let streams = stdMocks.flush();
+		assert.equal( streams.stdout.join(''), output);
+		assert.equal( streams.stderr.join(''), errors);
+	}
+}

--- a/test/runtime/tsconfig.json
+++ b/test/runtime/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "module": "commonjs",
+    "target": "es2015",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "experimentalDecorators": true,
+    "declaration": false,
+    "preserveConstEnums": true,
+    "typeRoots": [
+      "./node_modules/@types"
+    ],
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/test/runtime/tsconfig.json
+++ b/test/runtime/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "outDir": "../../target/test/runtime",
     "sourceMap": true,
     "module": "commonjs",
     "target": "es2015",

--- a/tool/package.json
+++ b/tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antlr4ts-cli",
-  "version": "0.2.2-0",
+  "version": "0.4.0-SNAPSHOT",
   "preferGlobal": true,
   "description": "Antlr4 command line tool for TypeScript",
   "files": [
@@ -13,13 +13,9 @@
     "antlr4ts": "./antlr4ts"
   },
   "scripts": {
-    "prepublish": "mvn verify -DskipTests=true",
-    "postpack": "mv %npm_package_name%-%npm_package_version%.tgz ../%npm_package_name%.tgz",
-    "pretest": "npm install .",
-    "posttest": "cd .. && npm install tool",
-    "test": "antlr4ts",
-    "set": "set"
-  },
+    "prepublish": "mvn verify",
+    "postpack": "mv %npm_package_name%-%npm_package_version%.tgz ../%npm_package_name%.tgz"
+    },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tunnelvisionlabs/antlr4ts.git"

--- a/tool/package.json
+++ b/tool/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "prepublish": "mvn verify",
     "postpack": "mv %npm_package_name%-%npm_package_version%.tgz ../%npm_package_name%.tgz"
-    },
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tunnelvisionlabs/antlr4ts.git"

--- a/tool/src/org/antlr/v4/TypeScriptTool.java
+++ b/tool/src/org/antlr/v4/TypeScriptTool.java
@@ -17,6 +17,7 @@ import org.antlr.v4.tool.Grammar;
  * @author Sam Harwell
  */
 public class TypeScriptTool extends Tool {
+	protected boolean verbose = false;
 
 	static {
 		Grammar.parserOptions.add("baseImportPath");
@@ -42,6 +43,7 @@ public class TypeScriptTool extends Tool {
 
 	public static void main(String[] args) {
 		Tool antlr = new TypeScriptTool(args);
+		antlr.verbose = true;
 		if (args.length == 0) {
 			antlr.help();
 			antlr.exit(0);
@@ -79,7 +81,9 @@ public class TypeScriptTool extends Tool {
 			// for subdir/T.g4, you get subdir here.  Well, depends on -o etc...
 			File outputDir = getOutputDirectory(g.fileName);
 			File outputFile = new File(outputDir, fileName);
-			System.out.format("Generating file '%s' for grammar '%s'%n", outputFile.getAbsolutePath(), g.fileName);
+			if (this.verbose) {
+				System.out.format("Generating file '%s' for grammar '%s'%n", outputFile.getAbsolutePath(), g.fileName);
+			}
 		}
 
 		return super.getOutputFileWriter(g, fileName);

--- a/tool/src/org/antlr/v4/TypeScriptTool.java
+++ b/tool/src/org/antlr/v4/TypeScriptTool.java
@@ -17,7 +17,7 @@ import org.antlr.v4.tool.Grammar;
  * @author Sam Harwell
  */
 public class TypeScriptTool extends Tool {
-	protected boolean verbose = false;
+	private boolean verbose = false;
 
 	static {
 		Grammar.parserOptions.add("baseImportPath");
@@ -42,7 +42,7 @@ public class TypeScriptTool extends Tool {
 	}
 
 	public static void main(String[] args) {
-		Tool antlr = new TypeScriptTool(args);
+		TypeScriptTool antlr = new TypeScriptTool(args);
 		antlr.verbose = true;
 		if (args.length == 0) {
 			antlr.help();

--- a/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
+++ b/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
@@ -18,7 +18,14 @@ import org.stringtemplate.v4.ST;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.Assert.assertTrue;
 
@@ -165,7 +172,8 @@ public abstract class BaseTest {
 		this.stderrDuringParse = null;
 		if (parserName == null) {
 			writeLexerTestFile(lexerName, false);
-		} else {
+		}
+		else {
 			writeParserTestFile(parserName, lexerName, startRuleName, debug);
 		}
 	}
@@ -225,25 +233,24 @@ public abstract class BaseTest {
 	{
 		ST outputFileST = new ST(
 				"import 'mocha';\n" +
-						"import * as base from '../../../BaseTest';\n" +
-						"import { <lexerName> } from './<lexerName>';\n" +
-						"import { <parserName> } from './<parserName>';\n" +
-						"\n" +
-						"it(`<className>.<testName>`, ()=> {\n" +
-						"	base.parserTest( {\n" +
-						"		testName: `<testName>`,\n" +
-						"		lexer: <lexerName>, \n" +
-						"		parser: <parserName>, \n" +
-						"		parserStartRule: parser => parser.<parserStartRuleName>(),\n" +
-						"		debug: <debug>,\n" +
-						"		input: `<input>`,\n" +
-						"		expectedOutput: `<expectedOutput>`,\n" +
-						"		expectedErrors: `<expectedErrors>`,\n" +
-						"		showDFA: <showDFA>\n" +
-						"		});\n" +
-						"	});\n" +
-						"\n"
-		);
+				"import * as base from '../../../BaseTest';\n" +
+				"import { <lexerName> } from './<lexerName>';\n" +
+				"import { <parserName> } from './<parserName>';\n" +
+				"\n" +
+				"it(`<className>.<testName>`, ()=> {\n" +
+				"	base.parserTest( {\n" +
+				"		testName: `<testName>`,\n" +
+				"		lexer: <lexerName>, \n" +
+				"		parser: <parserName>, \n" +
+				"		parserStartRule: parser => parser.<parserStartRuleName>(),\n" +
+				"		debug: <debug>,\n" +
+				"		input: `<input>`,\n" +
+				"		expectedOutput: `<expectedOutput>`,\n" +
+				"		expectedErrors: `<expectedErrors>`,\n" +
+				"		showDFA: <showDFA>\n" +
+				"		});\n" +
+				"	});\n" +
+				"\n");
 
 		outputFileST.add("className", getClass().getSimpleName());
 		outputFileST.add("testName", this.name.getMethodName());
@@ -261,21 +268,20 @@ public abstract class BaseTest {
 	private void writeLexerTestFile(String lexerName, boolean showDFA) {
 		ST outputFileST = new ST(
 				"import 'mocha';\n" +
-						"import * as base from '../../../BaseTest';\n" +
-						"import { <lexerName> } from './<lexerName>';\n" +
-						"\n" +
-						"it(`<className>.<testName>`, ()=> {\n" +
-						"	base.lexerTest( {\n" +
-						"		testName: `<testName>`,\n" +
-						"		lexer: <lexerName>, \n" +
-						"		input: `<input>`,\n" +
-						"		expectedOutput: `<expectedOutput>`,\n" +
-						"		expectedErrors: `<expectedErrors>`,\n" +
-						"		showDFA: <showDFA>\n" +
-						"		});\n" +
-						"	});\n" +
-						"\n"
-		);
+				"import * as base from '../../../BaseTest';\n" +
+				"import { <lexerName> } from './<lexerName>';\n" +
+				"\n" +
+				"it(`<className>.<testName>`, ()=> {\n" +
+				"	base.lexerTest( {\n" +
+				"		testName: `<testName>`,\n" +
+				"		lexer: <lexerName>, \n" +
+				"		input: `<input>`,\n" +
+				"		expectedOutput: `<expectedOutput>`,\n" +
+				"		expectedErrors: `<expectedErrors>`,\n" +
+				"		showDFA: <showDFA>\n" +
+				"		});\n" +
+				"	});\n" +
+				"\n");
 
 		outputFileST.add("className", getClass().getSimpleName());
 		outputFileST.add("testName", this.name.getMethodName());

--- a/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
+++ b/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
@@ -57,7 +57,7 @@ public abstract class BaseTest {
 	public void setUp() throws Exception {
 		File cd = new File(".").getAbsoluteFile();
 		this.baseDir = cd.getParentFile().getParentFile();
-		this.classDir = new File(this.baseDir, "test/gen/" + getClass().getSimpleName() );
+		this.classDir = new File(this.baseDir, "test/runtime/gen/" + getClass().getSimpleName() );
 		this.testDir = new File(this.classDir, name.getMethodName());
 		this.testDir.mkdirs();
 		for (File file : this.testDir.listFiles()) {

--- a/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
+++ b/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
@@ -234,7 +234,7 @@ public abstract class BaseTest {
 						"		testName: `<testName>`,\n" +
 						"		lexer: <lexerName>, \n" +
 						"		parser: <parserName>, \n" +
-						"		parserStartRuleName: `<parserStartRuleName>`,\n" +
+						"		parserStartRule: parser => parser.<parserStartRuleName>(),\n" +
 						"		debug: <debug>,\n" +
 						"		input: `<input>`,\n" +
 						"		expectedOutput: `<expectedOutput>`,\n" +

--- a/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
+++ b/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
@@ -19,9 +19,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
+import org.junit.rules.*;
 import org.junit.runner.Description;
 import org.stringtemplate.v4.ST;
 
@@ -39,7 +37,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.rules.RuleChain;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -47,91 +44,26 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public abstract class BaseTest {
-	public static final String newline = System.getProperty("line.separator");
-	public static final String pathSep = System.getProperty("path.separator");
-
-	/**
-	 * When the {@code antlr-preserve-typescript-test-dir} runtime property is
-	 * set to {@code true}, the temporary directories created by the test run
-	 * will not be removed at the end of the test run, even for tests that
-	 * completed successfully.
-	 *
-	 * <p>
-	 * The default behavior (used in all other cases) is removing the temporary
-	 * directories for all tests which completed successfully, and preserving
-	 * the directories for tests which failed.</p>
-	 */
-	public static final boolean PRESERVE_TEST_DIR = Boolean.parseBoolean(System.getProperty("antlr-preserve-typescript-test-dir"));
-
-	private static boolean REMOVE_BASE_FOLDER = true;
-
-	@ClassRule
-	public static final TemporaryFolder BASE_TEST_FOLDER = new TemporaryFolder() {
-		@Override
-		public void create() throws IOException {
-			File testTmpdir = new File(System.getProperty("java.io.tmpdir"));
-			if (!testTmpdir.mkdirs()) {
-				assertTrue(testTmpdir.isDirectory());
-			}
-
-			super.create();
-		}
-
-		@Override
-		public void delete() {
-			if (REMOVE_BASE_FOLDER) {
-				super.delete();
-			}
-		}
-	};
-
-	/**
-	 * This is a JUnit rule which is applied in the correct order by {@link #tmpdirRuleChain}.
-	 */
-	public final TestRule testWatcher = new TestWatcher() {
-		@Override
-		protected void failed(Throwable e, Description description) {
-			REMOVE_BASE_FOLDER = false;
-			removeTestFolder = false;
-		}
-
-		@Override
-		protected void succeeded(Description description) {
-			// remove tmpdir if no error.
-			if (PRESERVE_TEST_DIR) {
-				REMOVE_BASE_FOLDER = false;
-				removeTestFolder = false;
-			}
-		}
-	};
-
-	private boolean removeTestFolder = true;
-
-	/**
-	 * This is a JUnit rule which is applied in the correct order by {@link #tmpdirRuleChain}.
-	 */
-	public final TemporaryFolder TEST_SRC_FOLDER = new TemporaryFolder(BASE_TEST_FOLDER.getRoot()) {
-		@Override
-		public void delete() {
-			if (removeTestFolder) {
-				super.delete();
-			}
-		}
-	};
+	private File baseDir;
+	private File classDir;
+	private File testDir;
 
 	public String tmpdir;
-
-	@Rule
-	public final RuleChain tmpdirRuleChain = RuleChain.outerRule(TEST_SRC_FOLDER).around(testWatcher);
-
-	/** If error during parser execution, store stderr here; can't return
-     *  stdout and stderr.  This doesn't trap errors from running antlr.
-     */
 	protected String stderrDuringParse;
+
+	@Rule public TestName name = new TestName();
 
 	@Before
 	public void setUp() throws Exception {
-		tmpdir = TEST_SRC_FOLDER.getRoot().getAbsolutePath();
+		File cd = new File(".").getAbsoluteFile();
+		this.baseDir = cd.getParentFile().getParentFile();
+		this.classDir = new File(this.baseDir, "test/gen/" + getClass().getSimpleName() );
+		this.testDir = new File(this.classDir, name.getMethodName());
+		this.testDir.mkdirs();
+		for (File file : this.testDir.listFiles()) {
+			file.delete();
+		}
+		this.tmpdir = this.testDir.getAbsolutePath();
 	}
 
     protected org.antlr.v4.Tool newTool(String[] args) {
@@ -174,7 +106,6 @@ public abstract class BaseTest {
 	protected ErrorQueue antlr(String grammarFileName, boolean defaultListener, String... extraOptions) {
 		final List<String> options = new ArrayList<String>();
 		Collections.addAll(options, extraOptions);
-		options.add("-DbaseImportPath=src");
 		// Uncomment the following lines to show the StringTemplate visualizer when running tests
 		//options.add("-XdbgST");
 		//options.add("-XdbgSTWait");
@@ -256,7 +187,6 @@ public abstract class BaseTest {
 		assertTrue(success);
 		writeFile(tmpdir, "input", input);
 		writeLexerTestFile(lexerName, showDFA);
-		addSourceFiles("Test.ts");
 		if(!compile()) {
 			fail("Failed to compile!");
 			return stderrDuringParse;
@@ -370,23 +300,21 @@ public abstract class BaseTest {
 				return false;
 			}
 
-			if(!buildProject()) {
-				return false;
-			}
+			return buildProject();
 
-			return true;
 		} catch(Exception e) {
+			System.err.println("Error during build: " + e.getMessage());
 			return false;
 		}
 	}
 
 	private boolean buildProject() throws Exception {
 		String tsc = locateTypeScriptCompiler();
-		String script = new File(BASE_TEST_FOLDER.getRoot(), "node_modules").isDirectory() ? "test" : "install";
-		String[] args = { locateNpm(), script };
+		String[] args = { tsc };
+
 		System.err.println("Starting build "+ Utils.join(args, " "));
 		ProcessBuilder pb = new ProcessBuilder(args);
-		pb.directory(BASE_TEST_FOLDER.getRoot());
+		pb.directory(testDir);
 		Process process = pb.start();
 		StreamVacuum stdoutVacuum = new StreamVacuum(process.getInputStream());
 		StreamVacuum stderrVacuum = new StreamVacuum(process.getErrorStream());
@@ -405,7 +333,7 @@ public abstract class BaseTest {
 	}
 
 	private String locateTypeScriptCompiler() {
-		return "tsc";
+		return "tsc.cmd";
 	}
 
 	private String locateNode() {
@@ -422,20 +350,6 @@ public abstract class BaseTest {
 		return "node";
 	}
 
-	private String locateNpm() {
-		String programFiles = System.getenv("PROGRAMFILES");
-		if (programFiles != null && new File(new File(programFiles, "nodejs"), "npm.cmd").isFile()) {
-			return new File(new File(programFiles, "nodejs"), "npm.cmd").getAbsolutePath();
-		}
-
-		programFiles = System.getenv("PROGRAMFILES(x86)");
-		if (programFiles != null && new File(new File(programFiles, "nodejs"), "npm.cmd").isFile()) {
-			return new File(new File(programFiles, "nodejs"), "npm.cmd").getAbsolutePath();
-		}
-
-		return "npm";
-	}
-
 	public boolean createProject() {
 		try {
 			String pack = BaseTest.class.getPackage().getName().replace(".", "/") + "/";
@@ -445,25 +359,6 @@ public abstract class BaseTest {
 			InputStream input = loader.getResourceAsStream(pack + tsconfigName);
 			File outputFile = new File(tmpdir, "tsconfig.json");
 			FileUtils.copyInputStreamToFile(input, outputFile);
-			String tsconfigText = FileUtils.readFileToString(outputFile, "UTF-8");
-
-			String externalForm = loader.getResource(pack + tsconfigName).toExternalForm();
-			externalForm = externalForm.substring(0, externalForm.indexOf("tool/target"));
-			String antlr4ts = new File(new File(new URL(externalForm).toURI()).getAbsoluteFile(), "target\\src").getAbsolutePath().replace('\\', '/');
-			tsconfigText = tsconfigText.replace("$$ANTLR4TS$$", antlr4ts);
-
-			FileUtils.writeStringToFile(outputFile, tsconfigText.replace("$$src$$", "."), "UTF-8");
-			outputFile = new File(BASE_TEST_FOLDER.getRoot(), "tsconfig.json");
-			FileUtils.writeStringToFile(outputFile, tsconfigText.replace("$$src$$", TEST_SRC_FOLDER.getRoot().getName()), "UTF-8");
-
-			String packageName = "package.json";
-			input = loader.getResourceAsStream(pack + packageName);
-			outputFile = new File(BASE_TEST_FOLDER.getRoot(), "package.json");
-			FileUtils.copyInputStreamToFile(input, outputFile);
-			input = loader.getResourceAsStream(pack + packageName);
-			outputFile = new File(TEST_SRC_FOLDER.getRoot(), "package.json");
-			FileUtils.copyInputStreamToFile(input, outputFile);
-
 			return true;
 		} catch(Exception e) {
 			e.printStackTrace(System.err);
@@ -474,7 +369,7 @@ public abstract class BaseTest {
 	public String execTest() {
 		try {
 			String node = locateNode();
-			String[] args = new String[] { node, "./" + TEST_SRC_FOLDER.getRoot().getName() + "/Test.js", new File(tmpdir, "input").getAbsolutePath() };
+			String[] args = new String[] { node, tmpdir + "/Test.js", new File(tmpdir, "input").getAbsolutePath() };
 			ProcessBuilder pb = new ProcessBuilder(args);
 
 			// Get the location of the compiled TypeScript runtime for use as the NODE_PATH
@@ -482,11 +377,7 @@ public abstract class BaseTest {
 			String tsconfigName = "tsconfig.json";
 			final ClassLoader loader = Thread.currentThread().getContextClassLoader();
 			String externalForm = loader.getResource(pack + tsconfigName).toExternalForm();
-			externalForm = externalForm.substring(0, externalForm.indexOf("tool/target"));
-			String antlr4ts = new File(new File(new URL(externalForm).toURI()).getAbsoluteFile(), "target").getAbsolutePath();
-
-			pb.environment().put("NODE_PATH", antlr4ts);
-			pb.directory(BASE_TEST_FOLDER.getRoot());
+			pb.directory(testDir);
 			Process process = pb.start();
 			StreamVacuum stdoutVacuum = new StreamVacuum(process.getInputStream());
 			StreamVacuum stderrVacuum = new StreamVacuum(process.getErrorStream());
@@ -651,15 +542,15 @@ public abstract class BaseTest {
 	{
 		ST outputFileST = new ST(
 			"require('source-map-support').install();\n" +
-			"import { ANTLRInputStream } from 'src/ANTLRInputStream';\n" +
-			"import { CommonTokenStream } from 'src/CommonTokenStream';\n" +
-			"import { DiagnosticErrorListener } from 'src/DiagnosticErrorListener';\n" +
-			"import { ErrorNode } from 'src/tree/ErrorNode';\n" +
-			"import { ParserRuleContext } from 'src/ParserRuleContext';\n" +
-			"import { ParseTreeListener } from 'src/tree/ParseTreeListener';\n" +
-			"import { ParseTreeWalker } from 'src/tree/ParseTreeWalker';\n" +
-			"import { RuleNode } from 'src/tree/RuleNode';\n" +
-			"import { TerminalNode } from 'src/tree/TerminalNode';\n" +
+			"import { ANTLRInputStream } from 'antlr4ts/ANTLRInputStream';\n" +
+			"import { CommonTokenStream } from 'antlr4ts/CommonTokenStream';\n" +
+			"import { DiagnosticErrorListener } from 'antlr4ts/DiagnosticErrorListener';\n" +
+			"import { ErrorNode } from 'antlr4ts/tree/ErrorNode';\n" +
+			"import { ParserRuleContext } from 'antlr4ts/ParserRuleContext';\n" +
+			"import { ParseTreeListener } from 'antlr4ts/tree/ParseTreeListener';\n" +
+			"import { ParseTreeWalker } from 'antlr4ts/tree/ParseTreeWalker';\n" +
+			"import { RuleNode } from 'antlr4ts/tree/RuleNode';\n" +
+			"import { TerminalNode } from 'antlr4ts/tree/TerminalNode';\n" +
 			"\n" +
 			"import * as fs from 'fs';\n" +
 			"\n" +
@@ -701,10 +592,10 @@ public abstract class BaseTest {
 	protected void writeLexerTestFile(String lexerName, boolean showDFA) {
 		ST outputFileST = new ST(
 			"require('source-map-support').install();\n" +
-			"import { ANTLRInputStream } from 'src/ANTLRInputStream';\n" +
-			"import { CharStream } from 'src/CharStream';\n" +
-			"import { CommonTokenStream } from 'src/CommonTokenStream';\n" +
-			"import { Lexer } from 'src/Lexer';\n" +
+			"import { ANTLRInputStream } from 'antlr4ts/ANTLRInputStream';\n" +
+			"import { CharStream } from 'antlr4ts/CharStream';\n" +
+			"import { CommonTokenStream } from 'antlr4ts/CommonTokenStream';\n" +
+			"import { Lexer } from 'antlr4ts/Lexer';\n" +
 			"import * as fs from 'fs';\n" +
 			"\n" +
 			"import { <lexerName> } from './<lexerName>';\n" +

--- a/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
+++ b/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
@@ -160,7 +160,7 @@ public abstract class BaseTest {
 	}
 
 	protected ErrorQueue antlr(String grammarFileName, String grammarStr, boolean defaultListener, String... extraOptions) {
-		System.out.println("dir "+tmpdir);
+		System.out.println("\nCreating " + tmpdir);
 		mkdir(tmpdir);
 		writeFile(tmpdir, grammarFileName, grammarStr);
 		return antlr(grammarFileName, defaultListener, extraOptions);
@@ -311,8 +311,6 @@ public abstract class BaseTest {
 	private boolean buildProject() throws Exception {
 		String tsc = locateTypeScriptCompiler();
 		String[] args = { tsc };
-
-		System.err.println("Starting build "+ Utils.join(args, " "));
 		ProcessBuilder pb = new ProcessBuilder(args);
 		pb.directory(testDir);
 		Process process = pb.start();

--- a/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
+++ b/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
@@ -333,7 +333,7 @@ public abstract class BaseTest {
 	}
 
 	private String locateTypeScriptCompiler() {
-		return "tsc.cmd";
+		return new File( baseDir, "node_modules/.bin/tsc.cmd").getAbsolutePath();
 	}
 
 	private String locateNode() {

--- a/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
+++ b/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
@@ -30,15 +30,14 @@ public abstract class BaseTest {
 	protected String expectedErrors;
 	private String stderrDuringParse;
 
-	/*
+	/**
 	 * Generates EcmaScript2015 style Template String body (WITHOUTout surrounding back-ticks)
 	 */
-
 	private static String asTemplateString(String text) {
 		return text
 			.replaceAll("\\\\","\\\\\\\\")
 			.replaceAll("`", "\\`")
-			.replace("\\$\\{", "$\\{");
+			.replaceAll("\\$\\{", "$\\{");
 	}
 
 	public static void writeFile(String dir, String fileName, String content) {

--- a/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
+++ b/tool/test/org/antlr/v4/test/runtime/typescript/BaseTest.java
@@ -7,114 +7,76 @@ package org.antlr.v4.test.runtime.typescript;
 
 import org.antlr.v4.Tool;
 import org.antlr.v4.TypeScriptTool;
-import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.TokenSource;
-import org.antlr.v4.runtime.WritableToken;
 import org.antlr.v4.runtime.misc.Utils;
 import org.antlr.v4.tool.ANTLRMessage;
 import org.antlr.v4.tool.DefaultToolListener;
-import org.antlr.v4.tool.GrammarSemanticsMessage;
-import org.apache.commons.io.FileUtils;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Rule;
-import org.junit.rules.*;
-import org.junit.runner.Description;
+import org.junit.rules.TestName;
 import org.stringtemplate.v4.ST;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public abstract class BaseTest {
-	private File baseDir;
-	private File classDir;
-	private File testDir;
-
 	public String tmpdir;
-	protected String stderrDuringParse;
-
 	@Rule public TestName name = new TestName();
 	protected String input;
 	protected String expectedOutput;
 	protected String expectedErrors;
+	private String stderrDuringParse;
+
+	/*
+	 * Generates EcmaScript2015 style Template String body (WITHOUTout surrounding back-ticks)
+	 */
+
+	private static String asTemplateString(String text) {
+		return text
+			.replaceAll("\\\\","\\\\\\\\")
+			.replaceAll("`", "\\`")
+			.replace("\\$\\{", "$\\{");
+	}
+
+	public static void writeFile(String dir, String fileName, String content) {
+		try {
+			Utils.writeFile(dir+"/"+fileName, content, "UTF-8");
+		}
+		catch (IOException ioe) {
+			System.err.println("can't write file");
+			ioe.printStackTrace(System.err);
+		}
+	}
+
+	protected static void assertEquals(String msg, int a, int b) {
+		org.junit.Assert.assertEquals(msg, a, b);
+	}
+
+	protected static void assertEquals(String a, String b) {
+		org.junit.Assert.assertEquals(a, b);
+	}
 
 	@Before
 	public void setUp() throws Exception {
 		File cd = new File(".").getAbsoluteFile();
-		this.baseDir = cd.getParentFile().getParentFile();
-		this.classDir = new File(this.baseDir, "test/runtime/gen/" + getClass().getSimpleName() );
-		this.testDir = new File(this.classDir, name.getMethodName());
-		this.testDir.mkdirs();
-		for (File file : this.testDir.listFiles()) {
+		File baseDir = cd.getParentFile().getParentFile();
+		File classDir = new File(baseDir, "test/runtime/gen/" + getClass().getSimpleName());
+		File testDir = new File(classDir, name.getMethodName());
+		testDir.mkdirs();
+		for (File file : testDir.listFiles()) {
 			file.delete();
 		}
-		this.tmpdir = this.testDir.getAbsolutePath();
+		this.tmpdir = testDir.getAbsolutePath();
 	}
 
-    protected org.antlr.v4.Tool newTool(String[] args) {
-		Tool tool = new TypeScriptTool(args);
-		return tool;
+    private org.antlr.v4.Tool newTool(String[] args) {
+		return new TypeScriptTool(args);
 	}
 
-	protected Tool newTool() {
-		org.antlr.v4.Tool tool = new TypeScriptTool(new String[] {"-o", tmpdir});
-		return tool;
-	}
-
-	protected static String asTemplateString( String text ) {
-		String result = text
-			.replaceAll("\\\\","\\\\\\\\")
-			.replaceAll("`", "\\`")
-			.replace("\\$\\{", "$\\{");
-		return result;
-	} 
-
-	protected String load(String fileName, String encoding)
-		throws IOException
-	{
-		if ( fileName==null ) {
-			return null;
-		}
-
-		String fullFileName = getClass().getPackage().getName().replace('.', '/') + '/' + fileName;
-		int size = 65000;
-		InputStreamReader isr;
-		InputStream fis = getClass().getClassLoader().getResourceAsStream(fullFileName);
-		if ( encoding!=null ) {
-			isr = new InputStreamReader(fis, encoding);
-		}
-		else {
-			isr = new InputStreamReader(fis);
-		}
-		try {
-			char[] data = new char[size];
-			int n = isr.read(data);
-			return new String(data, 0, n);
-		}
-		finally {
-			isr.close();
-		}
-	}
-
-	protected ErrorQueue antlr(String grammarFileName, boolean defaultListener, String... extraOptions) {
+	private ErrorQueue antlr(String grammarFileName, boolean defaultListener, String... extraOptions) {
 		final List<String> options = new ArrayList<String>();
 		Collections.addAll(options, extraOptions);
 		// Uncomment the following lines to show the StringTemplate visualizer when running tests
@@ -170,8 +132,7 @@ public abstract class BaseTest {
 		return equeue;
 	}
 
-	protected ErrorQueue antlr(String grammarFileName, String grammarStr, boolean defaultListener, String... extraOptions) {
-		System.out.println("\nCreating " + tmpdir);
+	private ErrorQueue antlr(String grammarFileName, String grammarStr, boolean defaultListener, String... extraOptions) {
 		mkdir(tmpdir);
 		writeFile(tmpdir, grammarFileName, grammarStr);
 		return antlr(grammarFileName, defaultListener, extraOptions);
@@ -180,7 +141,6 @@ public abstract class BaseTest {
 	protected void generateLexerTest(String grammarFileName,
 							   String grammarStr,
 							   String lexerName,
-							   String input,
 							   boolean showDFA)
 	{
 		boolean success = rawGenerateRecognizer(grammarFileName,
@@ -196,7 +156,6 @@ public abstract class BaseTest {
 									  String parserName,
 									  String lexerName,
 									  String startRuleName,
-									  String input,
 									  boolean debug) {
 		boolean success = rawGenerateRecognizer(grammarFileName,
 				grammarStr,
@@ -212,82 +171,23 @@ public abstract class BaseTest {
 		}
 	}
 
-	protected String execLexer(String grammarFileName,
-							   String grammarStr,
-							   String lexerName,
-							   String input)
-	{
-		return execLexer(grammarFileName, grammarStr, lexerName, input, false);
-	}
-
-	protected String execLexer(String grammarFileName,
-							   String grammarStr,
-							   String lexerName,
-							   String input,
-							   boolean showDFA)
-	{
-		boolean success = rawGenerateRecognizer(grammarFileName,
-									  grammarStr,
-									  null,
-									  lexerName);
-		assertTrue(success);
-		writeFile(tmpdir, "input", input);
-		writeLexerTestFile(lexerName, showDFA);
-		if(!compile()) {
-			fail("Failed to compile!");
-			return stderrDuringParse;
-		}
-		String output = execTest();
-		if ( stderrDuringParse!=null && stderrDuringParse.length()>0 ) {
-			System.err.println(stderrDuringParse);
-		}
-		return output;
-	}
-
-	Set<String> sourceFiles = new HashSet<String>();
-
-	private void addSourceFiles(String ... files) {
-		for(String file : files)
-			this.sourceFiles.add(file);
-	}
-
-	protected String execParser(String grammarFileName,
-								String grammarStr,
-								String parserName,
-								String lexerName,
-								String startRuleName,
-								String input, boolean debug)
-	{
-		boolean success = rawGenerateRecognizer(grammarFileName,
-														grammarStr,
-														parserName,
-														lexerName,
-														"-visitor");
-		assertTrue(success);
-		writeFile(tmpdir, "input", input);
-		return rawExecRecognizer(parserName,
-								 lexerName,
-								 startRuleName,
-								 debug);
-	}
-
 	/** Return true if all is well */
-	protected boolean rawGenerateRecognizer(String grammarFileName,
-													String grammarStr,
-													String parserName,
-													String lexerName,
-													String... extraOptions)
+	private boolean rawGenerateRecognizer(String grammarFileName,
+										  String grammarStr,
+										  String parserName,
+										  String lexerName,
+										  String... extraOptions)
 	{
 		return rawGenerateRecognizer(grammarFileName, grammarStr, parserName, lexerName, false, extraOptions);
 	}
 
 	/** Return true if all is well */
-	protected boolean rawGenerateRecognizer(String grammarFileName,
-													String grammarStr,
-													String parserName,
-													String lexerName,
-													boolean defaultListener,
-													String... extraOptions)
+	private boolean rawGenerateRecognizer(String grammarFileName,
+										  String grammarStr,
+										  String parserName,
+										  String lexerName,
+										  boolean defaultListener,
+										  String... extraOptions)
 	{
 		ErrorQueue equeue = antlr(grammarFileName, grammarStr, defaultListener, extraOptions);
 		if (!equeue.errors.isEmpty()) {
@@ -311,267 +211,7 @@ public abstract class BaseTest {
 				files.add(grammarName+"BaseVisitor.ts");
 			}
 		}
-		addSourceFiles(files.toArray(new String[files.size()]));
 		return true;
-	}
-
-	protected String rawExecRecognizer(String parserName,
-									   String lexerName,
-									   String parserStartRuleName,
-									   boolean debug)
-	{
-        this.stderrDuringParse = null;
-		if ( parserName==null ) {
-			writeLexerTestFile(lexerName, false);
-		}
-		else {
-			writeParserTestFile(parserName,
-						  lexerName,
-						  parserStartRuleName,
-						  debug);
-		}
-
-		addSourceFiles("Test.ts");
-		return execRecognizer();
-	}
-
-	public String execRecognizer() {
-		assertTrue(compile());
-		return execTest();
-	}
-
-	public boolean compile() {
-		try {
-			if(!createProject()) {
-				return false;
-			}
-
-			return buildProject();
-
-		} catch(Exception e) {
-			System.err.println("Error during build: " + e.getMessage());
-			return false;
-		}
-	}
-
-	private boolean buildProject() throws Exception {
-		String tsc = locateTypeScriptCompiler();
-		String[] args = { tsc };
-		ProcessBuilder pb = new ProcessBuilder(args);
-		pb.directory(testDir);
-		Process process = pb.start();
-		StreamVacuum stdoutVacuum = new StreamVacuum(process.getInputStream());
-		StreamVacuum stderrVacuum = new StreamVacuum(process.getErrorStream());
-		stdoutVacuum.start();
-		stderrVacuum.start();
-		process.waitFor();
-		stdoutVacuum.join();
-		stderrVacuum.join();
-		// xbuild sends errors to output, so check exit code
-		boolean success = process.exitValue()==0;
-		if ( !success ) {
-			this.stderrDuringParse = stdoutVacuum.toString();
-			System.err.println("buildProject stderrVacuum: "+ this.stderrDuringParse);
-		}
-		return success;
-	}
-
-	private String locateTypeScriptCompiler() {
-		return new File( baseDir, "node_modules/.bin/tsc.cmd").getAbsolutePath();
-	}
-
-	private String locateNode() {
-		String programFiles = System.getenv("PROGRAMFILES");
-		if (programFiles != null && new File(new File(programFiles, "nodejs"), "node.exe").isFile()) {
-			return new File(new File(programFiles, "nodejs"), "node.exe").getAbsolutePath();
-		}
-
-		programFiles = System.getenv("PROGRAMFILES(x86)");
-		if (programFiles != null && new File(new File(programFiles, "nodejs"), "node.exe").isFile()) {
-			return new File(new File(programFiles, "nodejs"), "node.exe").getAbsolutePath();
-		}
-
-		return "node";
-	}
-
-	public boolean createProject() {
-		try {
-			String pack = BaseTest.class.getPackage().getName().replace(".", "/") + "/";
-
-			String tsconfigName = "tsconfig.json";
-			final ClassLoader loader = Thread.currentThread().getContextClassLoader();
-			InputStream input = loader.getResourceAsStream(pack + tsconfigName);
-			File outputFile = new File(tmpdir, "tsconfig.json");
-			FileUtils.copyInputStreamToFile(input, outputFile);
-			return true;
-		} catch(Exception e) {
-			e.printStackTrace(System.err);
-			return false;
-		}
-	}
-
-	public String execTest() {
-		try {
-			String node = locateNode();
-			String[] args = new String[] { node, tmpdir + "/Test.js", new File(tmpdir, "input").getAbsolutePath() };
-			ProcessBuilder pb = new ProcessBuilder(args);
-
-			// Get the location of the compiled TypeScript runtime for use as the NODE_PATH
-			String pack = BaseTest.class.getPackage().getName().replace(".", "/") + "/";
-			String tsconfigName = "tsconfig.json";
-			final ClassLoader loader = Thread.currentThread().getContextClassLoader();
-			String externalForm = loader.getResource(pack + tsconfigName).toExternalForm();
-			pb.directory(testDir);
-			Process process = pb.start();
-			StreamVacuum stdoutVacuum = new StreamVacuum(process.getInputStream());
-			StreamVacuum stderrVacuum = new StreamVacuum(process.getErrorStream());
-			stdoutVacuum.start();
-			stderrVacuum.start();
-			process.waitFor();
-			stdoutVacuum.join();
-			stderrVacuum.join();
-			String output = stdoutVacuum.toString();
-			if ( stderrVacuum.toString().length()>0 ) {
-				this.stderrDuringParse = stderrVacuum.toString();
-				System.err.println("exec stderrVacuum: "+ stderrVacuum);
-			}
-			return output;
-		}
-		catch (Exception e) {
-			System.err.println("can't exec recognizer");
-			e.printStackTrace(System.err);
-		}
-		return null;
-	}
-
-	public void testErrors(String[] pairs, boolean printTree) {
-        for (int i = 0; i < pairs.length; i+=2) {
-            String input = pairs[i];
-            String expect = pairs[i+1];
-
-			String[] lines = input.split("\n");
-			String fileName = getFilenameFromFirstLineOfGrammar(lines[0]);
-			ErrorQueue equeue = antlr(fileName, input, false);
-
-			String actual = equeue.toString(true);
-			actual = actual.replace(tmpdir + File.separator, "");
-			System.err.println(actual);
-			String msg = input;
-			msg = msg.replace("\n","\\n");
-			msg = msg.replace("\r","\\r");
-			msg = msg.replace("\t","\\t");
-
-			org.junit.Assert.assertEquals("error in: "+msg,expect,actual);
-        }
-    }
-
-	public String getFilenameFromFirstLineOfGrammar(String line) {
-		String fileName = "A" + Tool.GRAMMAR_EXTENSION;
-		int grIndex = line.lastIndexOf("grammar");
-		int semi = line.lastIndexOf(';');
-		if ( grIndex>=0 && semi>=0 ) {
-			int space = line.indexOf(' ', grIndex);
-			fileName = line.substring(space+1, semi)+Tool.GRAMMAR_EXTENSION;
-		}
-		if ( fileName.length()==Tool.GRAMMAR_EXTENSION.length() ) fileName = "A" + Tool.GRAMMAR_EXTENSION;
-		return fileName;
-	}
-
-
-	List<ANTLRMessage> getMessagesOfType(List<ANTLRMessage> msgs, Class<? extends ANTLRMessage> c) {
-		List<ANTLRMessage> filtered = new ArrayList<ANTLRMessage>();
-		for (ANTLRMessage m : msgs) {
-			if ( m.getClass() == c ) filtered.add(m);
-		}
-		return filtered;
-	}
-
-
-	public static class StreamVacuum implements Runnable {
-		StringBuilder buf = new StringBuilder();
-		BufferedReader in;
-		Thread sucker;
-		public StreamVacuum(InputStream in) {
-			this.in = new BufferedReader( new InputStreamReader(in) );
-		}
-		public void start() {
-			sucker = new Thread(this);
-			sucker.start();
-		}
-		@Override
-		public void run() {
-			try {
-				String line = in.readLine();
-				while (line!=null) {
-					buf.append(line);
-					buf.append('\n');
-					line = in.readLine();
-				}
-			}
-			catch (IOException ioe) {
-				System.err.println("can't read output from process");
-			}
-		}
-		/** wait for the thread to finish */
-		public void join() throws InterruptedException {
-			sucker.join();
-		}
-		@Override
-		public String toString() {
-			return buf.toString();
-		}
-	}
-
-	protected void checkGrammarSemanticsError(ErrorQueue equeue,
-											  GrammarSemanticsMessage expectedMessage)
-		throws Exception
-	{
-		ANTLRMessage foundMsg = null;
-		for (int i = 0; i < equeue.errors.size(); i++) {
-			ANTLRMessage m = equeue.errors.get(i);
-			if (m.getErrorType()==expectedMessage.getErrorType() ) {
-				foundMsg = m;
-			}
-		}
-		assertNotNull("no error; "+expectedMessage.getErrorType()+" expected", foundMsg);
-		assertTrue("error is not a GrammarSemanticsMessage",
-				   foundMsg instanceof GrammarSemanticsMessage);
-		assertEquals(Arrays.toString(expectedMessage.getArgs()), Arrays.toString(foundMsg.getArgs()));
-		if ( equeue.size()!=1 ) {
-			System.err.println(equeue);
-		}
-	}
-
-
-    public static class FilteringTokenStream extends CommonTokenStream {
-        public FilteringTokenStream(TokenSource src) { super(src); }
-        Set<Integer> hide = new HashSet<Integer>();
-        @Override
-        protected boolean sync(int i) {
-            if (!super.sync(i)) {
-				return false;
-			}
-
-			Token t = get(i);
-			if ( hide.contains(t.getType()) ) {
-				((WritableToken)t).setChannel(Token.HIDDEN_CHANNEL);
-			}
-
-			return true;
-        }
-        public void setTokenTypeChannel(int ttype, int channel) {
-            hide.add(ttype);
-        }
-    }
-
-	public static void writeFile(String dir, String fileName, String content) {
-		try {
-			Utils.writeFile(dir+"/"+fileName, content, "UTF-8");
-		}
-		catch (IOException ioe) {
-			System.err.println("can't write file");
-			ioe.printStackTrace(System.err);
-		}
 	}
 
 	protected void mkdir(String dir) {
@@ -579,10 +219,10 @@ public abstract class BaseTest {
 		f.mkdirs();
 	}
 
-	protected void writeParserTestFile(String parserName,
-								 String lexerName,
-								 String parserStartRuleName,
-								 boolean debug)
+	private void writeParserTestFile(String parserName,
+									 String lexerName,
+									 String parserStartRuleName,
+									 boolean debug)
 	{
 		ST outputFileST = new ST(
 				"import 'mocha';\n" +
@@ -619,7 +259,7 @@ public abstract class BaseTest {
 		writeFile(tmpdir, "Test.ts", outputFileST.render());
 	}
 
-	protected void writeLexerTestFile(String lexerName, boolean showDFA) {
+	private void writeLexerTestFile(String lexerName, boolean showDFA) {
 		ST outputFileST = new ST(
 				"import 'mocha';\n" +
 						"import * as base from '../../../BaseTest';\n" +
@@ -648,76 +288,9 @@ public abstract class BaseTest {
 		writeFile(tmpdir, "Test.ts", outputFileST.render());
 	}
 
-	public void writeRecognizerAndCompile(String parserName, String lexerName,
-										  String parserStartRuleName,
-										  boolean debug) {
-		if ( parserName==null ) {
-			writeLexerTestFile(lexerName, debug);
-		}
-		else {
-			writeParserTestFile(parserName,
-						  lexerName,
-						  parserStartRuleName,
-						  debug);
-		}
-
-		addSourceFiles("Test.ts");
-	}
-
-
-    protected void eraseFiles(final String filesEndingWith) {
-        File tmpdirF = new File(tmpdir);
-        String[] files = tmpdirF.list();
-        for(int i = 0; files!=null && i < files.length; i++) {
-            if ( files[i].endsWith(filesEndingWith) ) {
-                new File(tmpdir+"/"+files[i]).delete();
-            }
-        }
-    }
-
-    protected void eraseFiles() {
-		if (tmpdir == null) {
-			return;
-		}
-
-        File tmpdirF = new File(tmpdir);
-        String[] files = tmpdirF.list();
-        if(files!=null) for(String file : files) {
-        	new File(tmpdir+"/"+file).delete();
-        }
-    }
-
-    protected void eraseTempDir() {
-        File tmpdirF = new File(tmpdir);
-        if ( tmpdirF.exists() ) {
-            eraseFiles();
-            tmpdirF.delete();
-        }
-    }
-
-	public String getFirstLineOfException() {
-		if ( this.stderrDuringParse ==null ) {
-			return null;
-		}
-		String[] lines = this.stderrDuringParse.split("\n");
-		String prefix="Exception in thread \"main\" ";
-		return lines[0].substring(prefix.length(),lines[0].length());
-	}
-
 	public List<String> realElements(List<String> elements) {
 		return elements.subList(Token.MIN_USER_TOKEN_TYPE, elements.size());
 	}
-
-	public void assertNotNullOrEmpty(String message, String text) {
-		assertNotNull(message, text);
-		assertFalse(message, text.isEmpty());
-	}
-
-	public void assertNotNullOrEmpty(String text) {
-		assertNotNull(text);
-		assertFalse(text.isEmpty());
-	}
-
 
 	/** Return map sorted by key */
 	public <K extends Comparable<? super K>,V> LinkedHashMap<K,V> sort(Map<K,V> data) {
@@ -730,17 +303,4 @@ public abstract class BaseTest {
 		}
 		return dup;
 	}
-
-	protected static void assertEquals(String msg, int a, int b) {
-		org.junit.Assert.assertEquals(msg, a, b);
-	}
-
-	protected static void assertEquals(String a, String b) {
-		org.junit.Assert.assertEquals(a, b);
-	}
-
-	protected static void assertNull(String a) {
-		org.junit.Assert.assertNull(a);
-	}
-
 }

--- a/tool/test/org/antlr/v4/test/runtime/typescript/TypeScript.test.stg
+++ b/tool/test/org/antlr/v4/test/runtime/typescript/TypeScript.test.stg
@@ -41,14 +41,10 @@ public void test<test.name>() throws Exception {
 <if(test.AfterGrammar)>
 	<test.AfterGrammar>
 <endif>
-	String input =<writeStringLiteral(test.Input)>;
-	String found = execLexer("<grammar>.g4", grammar, "<grammar><if(test.Options.("CombinedGrammar"))>Lexer<endif>", input, <writeBoolean(test.Options.("ShowDFA"))>);
-	assertEquals(<writeStringLiteral(test.Output)>, found);
-	<if(!isEmpty.(test.Errors))>
-	assertEquals(<writeStringLiteral(test.Errors)>, this.stderrDuringParse);
-	<else>
-	assertNull(this.stderrDuringParse);
-	<endif>
+	this.input =<writeStringLiteral(test.Input)>;
+	this.expectedOutput = <writeStringLiteral(test.Output)>;
+	this.expectedErrors = <writeStringLiteral(test.Errors)>;
+	generateLexerTest("<grammar>.g4", grammar, "<grammar><if(test.Options.("CombinedGrammar"))>Lexer<endif>", input, <writeBoolean(test.Options.("ShowDFA"))>);
 	}>
 }
 
@@ -76,14 +72,10 @@ public void test<test.name>() throws Exception {
 
 	<test.AfterGrammar>
 
-	String input =<writeStringLiteral(test.Input)>;
-	String found = execParser("<grammar>.g4", grammar, "<grammar>Parser", "<grammar>Lexer", "<test.Rule>", input, <writeBoolean(test.Options.("Debug"))>);
-	assertEquals(<writeStringLiteral(test.Output)>, found);
-	<if(!isEmpty.(test.Errors))>
-	assertEquals(<writeStringLiteral(test.Errors)>, this.stderrDuringParse);
-	<else>
-	assertNull(this.stderrDuringParse);
-	<endif>
+	this.input =<writeStringLiteral(test.Input)>;
+	this.expectedOutput = <writeStringLiteral(test.Output)>;
+	this.expectedErrors = <writeStringLiteral(test.Errors)>;
+	generateParserTest("<grammar>.g4", grammar, "<grammar>Parser", "<grammar>Lexer", "<test.Rule>", input, <writeBoolean(test.Options.("Debug"))>);
 	}>
 }
 
@@ -96,7 +88,7 @@ CompositeParserTestMethod(test) ::= <<
 AbstractParserTestMethod(test) ::= <<
 String test<test.name>(String input) throws Exception {
 	String grammar = <test.grammar.lines:{ line | "<line>};separator="\\n\" +\n", wrap, anchor>";
-	return execParser("<test.grammar.grammarName>.g4", grammar, "<test.grammar.grammarName>Parser", "<test.grammar.grammarName>Lexer", "<test.startRule>", input, <test.debug>);
+	return generateParserTest("<test.grammar.grammarName>.g4", grammar, "<test.grammar.grammarName>Parser", "<test.grammar.grammarName>Lexer", "<test.startRule>", input, <test.debug>);
 }
 
 >>

--- a/tool/test/org/antlr/v4/test/runtime/typescript/TypeScript.test.stg
+++ b/tool/test/org/antlr/v4/test/runtime/typescript/TypeScript.test.stg
@@ -44,7 +44,7 @@ public void test<test.name>() throws Exception {
 	this.input =<writeStringLiteral(test.Input)>;
 	this.expectedOutput = <writeStringLiteral(test.Output)>;
 	this.expectedErrors = <writeStringLiteral(test.Errors)>;
-	generateLexerTest("<grammar>.g4", grammar, "<grammar><if(test.Options.("CombinedGrammar"))>Lexer<endif>", input, <writeBoolean(test.Options.("ShowDFA"))>);
+	generateLexerTest("<grammar>.g4", grammar, "<grammar><if(test.Options.("CombinedGrammar"))>Lexer<endif>", <writeBoolean(test.Options.("ShowDFA"))>);
 	}>
 }
 
@@ -75,7 +75,7 @@ public void test<test.name>() throws Exception {
 	this.input =<writeStringLiteral(test.Input)>;
 	this.expectedOutput = <writeStringLiteral(test.Output)>;
 	this.expectedErrors = <writeStringLiteral(test.Errors)>;
-	generateParserTest("<grammar>.g4", grammar, "<grammar>Parser", "<grammar>Lexer", "<test.Rule>", input, <writeBoolean(test.Options.("Debug"))>);
+	generateParserTest("<grammar>.g4", grammar, "<grammar>Parser", "<grammar>Lexer", "<test.Rule>", <writeBoolean(test.Options.("Debug"))>);
 	}>
 }
 
@@ -88,7 +88,7 @@ CompositeParserTestMethod(test) ::= <<
 AbstractParserTestMethod(test) ::= <<
 String test<test.name>(String input) throws Exception {
 	String grammar = <test.grammar.lines:{ line | "<line>};separator="\\n\" +\n", wrap, anchor>";
-	return generateParserTest("<test.grammar.grammarName>.g4", grammar, "<test.grammar.grammarName>Parser", "<test.grammar.grammarName>Lexer", "<test.startRule>", input, <test.debug>);
+	return generateParserTest("<test.grammar.grammarName>.g4", grammar, "<test.grammar.grammarName>Parser", "<test.grammar.grammarName>Lexer", "<test.startRule>", <test.debug>);
 }
 
 >>

--- a/tool/test/org/antlr/v4/test/runtime/typescript/TypeScript.test.stg
+++ b/tool/test/org/antlr/v4/test/runtime/typescript/TypeScript.test.stg
@@ -336,7 +336,7 @@ ParseTreeWalker.Default.Walk(new LeafListener(), <s>);
 
 TreeNodeWithAltNumField(X) ::= <<
 @parser::beforeParser {
-import { ParserRuleContext as PRC } from 'src/ParserRuleContext';
+import { ParserRuleContext as PRC } from 'antlr4ts/ParserRuleContext';
 
 export class MyRuleNode extends PRC {
 	altNum: number;

--- a/tool/test/org/antlr/v4/test/runtime/typescript/tsconfig.json
+++ b/tool/test/org/antlr/v4/test/runtime/typescript/tsconfig.json
@@ -16,16 +16,10 @@
     ],
     "types": [
       "node"
-    ],
-    "baseUrl": ".",
-    "paths": {
-      "src/*": [
-        "$$ANTLR4TS$$/*"
-      ]
-    }
+    ]
   },
   "include": [
-    "$$src$$/**/*"
+    "./*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
   "exclude": [
     "node_modules",
     "target",
-    "tool"
+    "tool",
+    "test/runtime"
   ]
 }


### PR DESCRIPTION
AKA lobotomize BaseTest.java.    This pull request changes the runtime test suite for antlr4ts to run natively under Mocha, rather than under JUnit.   

**BaseTest.java** no longer *runs* the tests, it just does the generation of TypeScript code for them.  The generated code ends up in **antlr4ts/test/runtime/gen**.

In addition to cleaning up the test process and making it easy to debug these tests, this substantially improves the performance of running the tests.    Test source fiels are now generated during build of "tool" directory, build as part of the root level build process, and run as a normal part of the test sequence.

The one slightly tricky aspect is that TypeScript compile of the generated tests has to wait until after the runtime has been build.    That means that a single background job running **tsc** wont recompiling them if the tests change, but since any change to the underlying **.stg** files defining the tests requires re-building the whole project, that doesn't seem an unreasonable a restriction.    You *can* make edits to the runtime and simply re-run the tests as long as the runtime's API doesn't change.     

The following sequence should build and run 410 tests (all passing) from the root directory:
```
npm install
npm test
```