### PR TITLE
Fix the wording of the BSD-3-Clause license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -11,8 +11,9 @@ are met:
  2. Redistributions in binary form must reproduce the above copyright
     notice, this list of conditions and the following disclaimer in the
     documentation and/or other materials provided with the distribution.
- 3. The name of the author may not be used to endorse or promote products
-    derived from this software without specific prior written permission.
+ 3. Neither the name of the copyright holder nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
 IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES


### PR DESCRIPTION
After talking with GitHub support, we found a slight deviation in our
LICENSE file from the text of the BSD-3-Clause license. This change
updates the license file to use that text verbatim.