### PR TITLE
Split large ATN into smaller strings

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
@@ -910,9 +910,22 @@ export <if(lexer.abstractRecognizer)>abstract <endif>class <lexer.name> extends 
 >>
 
 SerializedATN(model, className={<if(isLexer)><lexer.name><else><parser.name><endif>}) ::= <<
+<if(rest(model.segments))>
+<! requires segmented representation !>
+private static readonly _serializedATNSegments: number = <length(model.segments)>;
+<model.segments:{segment|private static readonly _serializedATNSegment<i0>: string =
+	"<segment; wrap={"+<\n><\t>"}>";}; separator="\n">
+public static readonly _serializedATN: string = Utils.join(
+	[
+		<model.segments:{segment | <className>._serializedATNSegment<i0>}; separator=",\n">
+	],
+	""
+);
+<else>
 <! only one segment, can be inlined !>
 public static readonly _serializedATN: string =
 	"<model.serialized; wrap={"+<\n><\t>"}>";
+<endif>
 public static __ATN: ATN;
 public static get _ATN(): ATN {
 	if (!<className>.__ATN) {

--- a/tool/src/org/antlr/v4/codegen/target/TypeScriptTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/TypeScriptTarget.java
@@ -127,6 +127,12 @@ public class TypeScriptTarget extends Target {
 	}
 
 	@Override
+	public int getSerializedATNSegmentLimit() {
+		// This number was arbitrarily chosen as a "large-ish number for which TestLargeLexer still passes"
+		return 10000;
+	}
+
+	@Override
 	protected boolean visibleGrammarSymbolCausesIssueInGeneratedCode(GrammarAST idNode) {
 		return false;
 	}

--- a/tool/src/org/antlr/v4/codegen/target/TypeScriptTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/TypeScriptTarget.java
@@ -129,7 +129,7 @@ public class TypeScriptTarget extends Target {
 	@Override
 	public int getSerializedATNSegmentLimit() {
 		// This number was arbitrarily chosen as a "large-ish number for which TestLargeLexer still passes"
-		return 10000;
+		return 5000;
 	}
 
 	@Override

--- a/tool/test/org/antlr/v4/test/runtime/typescript/TypeScript.test.stg
+++ b/tool/test/org/antlr/v4/test/runtime/typescript/TypeScript.test.stg
@@ -479,7 +479,6 @@ IgnoredTests ::= [
 	"SemPredEvalParser.2UnpredicatedAltsAndOneOrthogonalAlt": "Test does not support importing PredictionMode.",
 
 	// Skipped due to limitations in the TypeScript target
-	"LexerExec.LargeLexer": "Compiler fails for an unknown reason.",
 
 	default: false
 ]


### PR DESCRIPTION
* Fixes a stack overflow when attempting to compile the TS code
* Fixes `testLargeLexer`