### PR TITLE
Alternate iterable children implementation

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -578,7 +578,8 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 	enterLeftFactoredRule(localctx: ParserRuleContext, state: number, ruleIndex: number): void {
 		this.state = state;
 		if (this._buildParseTrees) {
-			let factoredContext = this._ctx.getChild(this._ctx.childCount - 1) as ParserRuleContext;
+			const children = this._ctx.children;
+			let factoredContext = children[children.length - 1] as ParserRuleContext;
 			this._ctx.removeLastChild();
 			factoredContext._parent = localctx;
 			localctx.addChild(factoredContext);

--- a/src/ParserRuleContext.ts
+++ b/src/ParserRuleContext.ts
@@ -51,11 +51,17 @@ export class ParserRuleContext extends RuleContext {
 	_children?: Array<ParseTree>;
 	static _emptyChildren = [];
 
+	/** Access children for read
+	 * Avoids creation of extra empty arrays by using a shared _emptyChildren array
+	 */
 	get children() : ReadonlyArray<ParseTree> {
 		let result = this._children;
 		return result ? result : ParserRuleContext._emptyChildren;
 	}
 
+	/** Access the children in a read/write way.
+	 * This will create the _children array if needed.
+	 */
 	get mutableChildren() {
 		if (!this._children) this._children = [];
 		return this._children as Array<ParseTree>;

--- a/src/ParserRuleContext.ts
+++ b/src/ParserRuleContext.ts
@@ -192,10 +192,8 @@ export class ParserRuleContext extends RuleContext {
 		throw new TypeError("Invalid parent type for ParserRuleContext");
 	}
 
-	getChild(i: number): ParseTree;
-	getChild<T extends ParseTree>(i: number, ctxType: { new (...args: any[]): T; }): T;
 	// Note: in TypeScript, order or arguments reversed
-	getChild<T extends ParseTree>(i: number, ctxType?: { new (...args: any[]): T; }): ParseTree {
+	getChild<T extends ParseTree>(i: number, ctxType: { new (...args: any[]): T; }): ParseTree {
 		if (!this.children || i < 0 || i >= this.children.length) {
 			throw new RangeError("index parameter must be between >= 0 and <= number of children.")
 		}
@@ -285,7 +283,7 @@ export class ParserRuleContext extends RuleContext {
 
 	// NOTE: argument order change from Java version
 	getRuleContext<T extends ParserRuleContext>(i: number, ctxType: { new (...args: any[]): T; }): T {
-		return this.getChild(i, ctxType);
+		return this.getChild(i, ctxType) as T;
 	}
 
 	tryGetRuleContext<T extends ParserRuleContext>(i: number, ctxType: { new (...args: any[]): T; }): T | undefined {

--- a/src/ParserRuleContext.ts
+++ b/src/ParserRuleContext.ts
@@ -46,7 +46,20 @@ export class ParserRuleContext extends RuleContext {
 	 *  operation because we don't the need to track the details about
 	 *  how we parse this rule.
 	 */
-	children?: ParseTree[];
+
+
+	_children?: Array<ParseTree>;
+	static _emptyChildren = [];
+
+	get children() : ReadonlyArray<ParseTree> {
+		let result = this._children;
+		return result ? result : ParserRuleContext._emptyChildren;
+	}
+
+	get mutableChildren() {
+		if (!this._children) this._children = [];
+		return this._children as Array<ParseTree>;
+	}
 
 	/** For debugging/tracing purposes, we want to track all of the nodes in
 	 *  the ATN traversed by the parser for a particular rule.
@@ -112,11 +125,10 @@ export class ParserRuleContext extends RuleContext {
 
 		// copy any error nodes to alt label node
 		if (ctx.children) {
-			this.children = [];
 			// reset parent pointer for any error nodes
 			for (let child of ctx.children) {
 				if (child instanceof ErrorNode) {
-					this.children.push(child);
+					this.mutableChildren.push(child);
 					child._parent = this;
 				}
 			}
@@ -143,12 +155,7 @@ export class ParserRuleContext extends RuleContext {
 			result = t;
 		}
 
-		if (!this.children) {
-			this.children = [t];
-		} else {
-			this.children.push(t);
-		}
-
+		this.mutableChildren.push(t);
 		return result;
 	}
 
@@ -158,7 +165,7 @@ export class ParserRuleContext extends RuleContext {
  	 */
 	removeLastChild(): void {
 		if (this.children) {
-			this.children.pop();
+			this.mutableChildren.pop();
 		}
 	}
 

--- a/src/ParserRuleContext.ts
+++ b/src/ParserRuleContext.ts
@@ -130,11 +130,12 @@ export class ParserRuleContext extends RuleContext {
 		this._stop = ctx._stop;
 
 		// copy any error nodes to alt label node
-		if (ctx.children) {
+		if (ctx.children.length) {
+			const children = this.mutableChildren;
 			// reset parent pointer for any error nodes
 			for (let child of ctx.children) {
 				if (child instanceof ErrorNode) {
-					this.mutableChildren.push(child);
+					children.push(child);
 					child._parent = this;
 				}
 			}

--- a/src/RuleContext.ts
+++ b/src/RuleContext.ts
@@ -125,13 +125,14 @@ export class RuleContext extends RuleNode {
 	 */
 	@Override
 	get text(): string {
-		if (this.childCount === 0) {
+		const children = this.children;
+		if (children.length === 0) {
 			return "";
 		}
 
 		let builder = "";
-		for (let i = 0; i < this.childCount; i++) {
-			builder += this.getChild(i).text;
+		for (let i = 0; i < children.length; i++) {
+			builder += children[i].text;
 		}
 
 		return builder.toString();
@@ -163,16 +164,6 @@ export class RuleContext extends RuleNode {
 	@Override
 	get children() : ReadonlyArray<ParseTree> {
 		return [] as ReadonlyArray<ParseTree>;
-	}
-
-	@Override
-	getChild(i: number): ParseTree {
-		throw new RangeError("i must be greater than or equal to 0 and less than childCount");
-	}
-
-	@Override
-	get childCount(): number {
-		return 0;
 	}
 
 	@Override

--- a/src/RuleContext.ts
+++ b/src/RuleContext.ts
@@ -161,6 +161,11 @@ export class RuleContext extends RuleNode {
 	set altNumber(altNumber: number) { }
 
 	@Override
+	get children() : ReadonlyArray<ParseTree> {
+		return [] as ReadonlyArray<ParseTree>;
+	}
+
+	@Override
 	getChild(i: number): ParseTree {
 		throw new RangeError("i must be greater than or equal to 0 and less than childCount");
 	}

--- a/src/tree/AbstractParseTreeVisitor.ts
+++ b/src/tree/AbstractParseTreeVisitor.ts
@@ -42,13 +42,13 @@ export abstract class AbstractParseTreeVisitor<Result> implements ParseTreeVisit
 	@Override
 	visitChildren(@NotNull node: RuleNode): Result {
 		let result: Result = this.defaultResult();
-		let n: number = node.childCount;
+		let n: number = node.children.length;
 		for (let i = 0; i < n; i++) {
 			if (!this.shouldVisitNextChild(node, result)) {
 				break;
 			}
 
-			let c: ParseTree = node.getChild(i);
+			let c: ParseTree = node.children[i];
 			let childResult: Result = c.accept(this);
 			result = this.aggregateResult(result, childResult);
 		}

--- a/src/tree/ParseTree.ts
+++ b/src/tree/ParseTree.ts
@@ -22,10 +22,7 @@ export interface ParseTree extends SyntaxTree {
 	readonly parent: ParseTree | undefined;
 
 	//@Override
-	readonly children: ReadonlyArray<ParseTree> | undefined;
-
-	//@Override
-	getChild(i: number): ParseTree;
+	readonly children: ReadonlyArray<ParseTree>;
 
 	/** The {@link ParseTreeVisitor} needs a double dispatch method. */
 	accept<T>(visitor: ParseTreeVisitor<T>): T;

--- a/src/tree/ParseTree.ts
+++ b/src/tree/ParseTree.ts
@@ -22,6 +22,9 @@ export interface ParseTree extends SyntaxTree {
 	readonly parent: ParseTree | undefined;
 
 	//@Override
+	readonly children: ReadonlyArray<ParseTree> | undefined;
+
+	//@Override
 	getChild(i: number): ParseTree;
 
 	/** The {@link ParseTreeVisitor} needs a double dispatch method. */

--- a/src/tree/ParseTreeWalker.ts
+++ b/src/tree/ParseTreeWalker.ts
@@ -34,11 +34,11 @@ export class ParseTreeWalker {
 			}
 
 			// Move down to first child, if exists
-			if (currentNode.childCount > 0) {
+			if (currentNode.children && currentNode.children.length > 0) {
 				nodeStack.push(currentNode);
 				indexStack.push(currentIndex);
 				currentIndex = 0;
-				currentNode = currentNode.getChild(0);
+				currentNode = currentNode.children[0];
 				continue;
 			}
 
@@ -59,7 +59,7 @@ export class ParseTreeWalker {
 				// Move to next sibling if possible
 				let last = nodeStack[nodeStack.length - 1];
 				currentIndex++;
-				currentNode = currentIndex < last.childCount ? last.getChild(currentIndex) : undefined;
+				currentNode = currentIndex < last.children.length ? last.children[currentIndex] : undefined;
 				if (currentNode) {
 					break;
 				}

--- a/src/tree/RuleNode.ts
+++ b/src/tree/RuleNode.ts
@@ -17,6 +17,9 @@ export abstract class RuleNode implements ParseTree {
 	//@Override
 	abstract readonly parent: RuleNode | undefined;
 
+	//@Override
+	abstract readonly children: ReadonlyArray<ParseTree>;
+
 	abstract getChild(i: number): ParseTree;
 
 	abstract accept<T>(visitor: ParseTreeVisitor<T>): T;

--- a/src/tree/RuleNode.ts
+++ b/src/tree/RuleNode.ts
@@ -12,15 +12,15 @@ import { Parser } from "../Parser";
 import { Interval } from "../misc/Interval";
 
 export abstract class RuleNode implements ParseTree {
+	protected static EmptyChildren: ReadonlyArray<ParseTree> = [];
+
 	abstract readonly ruleContext: RuleContext;
 
 	//@Override
 	abstract readonly parent: RuleNode | undefined;
 
 	//@Override
-	abstract readonly children: ReadonlyArray<ParseTree>;
-
-	abstract getChild(i: number): ParseTree;
+	get children() { return RuleNode.EmptyChildren; }
 
 	abstract accept<T>(visitor: ParseTreeVisitor<T>): T;
 
@@ -32,5 +32,4 @@ export abstract class RuleNode implements ParseTree {
 
 	abstract readonly payload: any;
 
-	abstract readonly childCount: number;
 }

--- a/src/tree/TerminalNode.ts
+++ b/src/tree/TerminalNode.ts
@@ -22,6 +22,11 @@ export class TerminalNode implements ParseTree {
 	}
 
 	@Override
+	get children() : ReadonlyArray<ParseTree> {
+		return [];
+	}
+
+	@Override
 	getChild(i: number): never {
 		throw new RangeError("Terminal Node has no children.");
 	}

--- a/src/tree/TerminalNode.ts
+++ b/src/tree/TerminalNode.ts
@@ -26,11 +26,6 @@ export class TerminalNode implements ParseTree {
 		return [];
 	}
 
-	@Override
-	getChild(i: number): never {
-		throw new RangeError("Terminal Node has no children.");
-	}
-
 	get symbol(): Token {
 		return this._symbol;
 	}

--- a/src/tree/Tree.ts
+++ b/src/tree/Tree.ts
@@ -14,7 +14,10 @@ export interface Tree {
 	 */
 	readonly parent: Tree | undefined;
 
-	readonly children: ReadonlyArray<Tree> | undefined;
+	/** The children of this node.
+	 *  For leaf nodes, this should return an empty array
+	 * */
+	readonly children: ReadonlyArray<Tree>;
 
 	/**
 	 * This method returns whatever object represents the data at this note. For
@@ -24,17 +27,6 @@ export interface Tree {
 	 * object.
 	 */
 	readonly payload: any;
-
-	/**
-	 * If there are children, get the `i`th value indexed from 0. Throws a `RangeError` if `i` is less than zero, or
-	 * greater than or equal to `childCount`.
-	 */
-	getChild(i: number): Tree;
-
-	/** How many children are there? If there is none, then this
-	 *  node represents a leaf node.
-	 */
-	readonly childCount: number;
 
 	/** Print out a whole tree, not just a node, in LISP format
 	 *  {@code (root child1 .. childN)}. Print just a node if this is a leaf.

--- a/src/tree/Tree.ts
+++ b/src/tree/Tree.ts
@@ -14,6 +14,8 @@ export interface Tree {
 	 */
 	readonly parent: Tree | undefined;
 
+	readonly children: ReadonlyArray<Tree> | undefined;
+
 	/**
 	 * This method returns whatever object represents the data at this note. For
 	 * example, for parse trees, the payload can be a {@link Token} representing

--- a/src/tree/Trees.ts
+++ b/src/tree/Trees.ts
@@ -225,7 +225,7 @@ export class Trees {
 			if (child instanceof ParserRuleContext && (range.b < startIndex || range.a > stopIndex)) {
 				if (Trees.isAncestorOf(child, root)) { // replace only if subtree doesn't have displayed root
 					let abbrev: CommonToken = new CommonToken(Token.INVALID_TYPE, "...");
-					t.children![i] = new TerminalNode(abbrev); // HACK access to private
+					t.mutableChildren[i] = new TerminalNode(abbrev); // HACK access to private
 				}
 			}
 		}

--- a/src/tree/Trees.ts
+++ b/src/tree/Trees.ts
@@ -41,15 +41,15 @@ export class Trees {
 		else { ruleNames = arg2 as string[]; }
 
 		let s: string = Utils.escapeWhitespace(this.getNodeText(t, ruleNames), false);
-		if (t.childCount == 0) return s;
+		if (t.children.length == 0) return s;
 		let buf = "";
 		buf += ("(");
 		s = Utils.escapeWhitespace(this.getNodeText(t, ruleNames), false);
 		buf += (s);
 		buf += (' ');
-		for (let i = 0; i < t.childCount; i++) {
+		for (let i = 0; i < t.children.length; i++) {
 			if (i > 0) buf += (' ');
-			buf += (this.toStringTree(t.getChild(i), ruleNames));
+			buf += (this.toStringTree(t.children[i], ruleNames));
 		}
 		buf += (")");
 		return buf;
@@ -95,8 +95,8 @@ export class Trees {
 	/** Return ordered list of all children of this node */
 	static getChildren(t: ParseTree): ParseTree[] {
 		let kids = [] as ParseTree[];
-		for (let i = 0; i < t.childCount; i++) {
-			kids.push(t.getChild(i));
+		for (let i = 0; i < t.children.length; i++) {
+			kids.push(t.children[i]);
 		}
 		return kids;
 	}
@@ -155,8 +155,8 @@ export class Trees {
 			if (t.ruleIndex === index) nodes.push(t);
 		}
 		// check children
-		for (let i = 0; i < t.childCount; i++) {
-			Trees._findAllNodes(t.getChild(i), index, findTokens, nodes);
+		for (let i = 0; i < t.children.length; i++) {
+			Trees._findAllNodes(t.children[i], index, findTokens, nodes);
 		}
 	}
 
@@ -169,9 +169,9 @@ export class Trees {
 
 		function recurse(e: ParseTree): void {
 			nodes.push(e);
-			const n = e.childCount;
+			const n = e.children.length;
 			for (let i = 0; i < n; i++) {
-				recurse(e.getChild(i));
+				recurse(e.children[i]);
 			}
 		}
 
@@ -188,9 +188,9 @@ export class Trees {
 		startTokenIndex: number, // inclusive
 		stopTokenIndex: number // inclusive
 	): ParserRuleContext | undefined {
-		let n: number = t.childCount;
+		let n: number = t.children.length;
 		for (let i = 0; i < n; i++) {
-			let child: ParseTree = t.getChild(i);
+			let child: ParseTree = t.children[i];
 			let r = Trees.getRootOfSubtreeEnclosingRegion(child, startTokenIndex, stopTokenIndex);
 			if (r) return r;
 		}
@@ -220,7 +220,7 @@ export class Trees {
 		if (!t) return;
 		let count = t.childCount;
 		for (let i = 0; i < count; i++) {
-			let child = t.getChild(i);
+			let child = t.children[i];
 			let range: Interval = child.sourceInterval;
 			if (child instanceof ParserRuleContext && (range.b < startIndex || range.a > stopIndex)) {
 				if (Trees.isAncestorOf(child, root)) { // replace only if subtree doesn't have displayed root
@@ -240,7 +240,7 @@ export class Trees {
 
 	//	let n: number =  t.childCount;
 	//	for (let i = 0 ; i < n ; i++){
-	//		let u: ParseTree =  findNodeSuchThat(t.getChild(i), pred);
+	//		let u: ParseTree =  findNodeSuchThat(t.children[i], pred);
 	//		if ( u!=null ) return u;
 	//	}
 	//	return null;

--- a/src/tree/pattern/ParseTreePatternMatcher.ts
+++ b/src/tree/pattern/ParseTreePatternMatcher.ts
@@ -339,7 +339,7 @@ export class ParseTreePatternMatcher {
 
 			let n: number = tree.childCount;
 			for (let i = 0; i < n; i++) {
-				let childMatch = this.matchImpl(tree.getChild(i), patternTree.getChild(i), labels);
+				let childMatch = this.matchImpl(tree.children[i], patternTree.children[i], labels);
 				if (childMatch) {
 					return childMatch;
 				}
@@ -355,8 +355,8 @@ export class ParseTreePatternMatcher {
 	/** Is {@code t} {@code (expr <expr>)} subtree? */
 	protected getRuleTagToken(t: ParseTree): RuleTagToken | undefined {
 		if (t instanceof RuleNode) {
-			if (t.childCount === 1 && t.getChild(0) instanceof TerminalNode) {
-				let c = t.getChild(0) as TerminalNode;
+			if (t.children.length === 1 && t.children[0] instanceof TerminalNode) {
+				let c = t.children[0] as TerminalNode;
 				if (c.symbol instanceof RuleTagToken) {
 //					System.out.println("rule tag subtree "+t.toStringTree(parser));
 					return c.symbol;

--- a/src/tree/xpath/XPath.ts
+++ b/src/tree/xpath/XPath.ts
@@ -210,7 +210,7 @@ export class XPath {
 		while (i < this.elements.length) {
 			let next = [] as ParseTree[]; // WAS LinkedHashSet<ParseTree>
 			for (let node of work) {
-				if (node.childCount > 0) {
+				if (node.children.length > 0) {
 					// only try to match next element if it has children
 					// e.g., //func/*/stat might have a token node for which
 					// we can't go looking for stat nodes.

--- a/test/runtime/BaseTest.ts
+++ b/test/runtime/BaseTest.ts
@@ -56,8 +56,9 @@ export interface ParserTestOptions<TParser extends Parser> extends LexerTestOpti
 
 class TreeShapeListener implements ParseTreeListener {
 	enterEveryRule(ctx: ParserRuleContext): void {
-		for (let i = 0; i < ctx.childCount; i++) {
-			let parent = ctx.getChild(i).parent;
+		const children = ctx.children;
+		for (let i = 0; i < children.length; i++) {
+			let parent = children[i].parent;
 			if (!(parent instanceof RuleNode) || parent.ruleContext !== ctx) {
 				throw new Error("Invalid parse tree shape detected.");
 			}


### PR DESCRIPTION
The idea behind this version is to simplify the `Tree` API, as discussed on PR #264.   Like that PR, it is intended to fix #262, and this is offered as a alternative for discussion.

Instead of Java-like `childCount` and `getChild()`, this uses a more JS/TS style approach to simply exposing a `children: ReadonlyArray<T>`.   This branch carries that through on all the related classes that implement `Tree` directly or indirectly.   

Note that getChild() still exists, but only in the two-argument form which selects the nth child of a given type.