### PR TITLE
Minor.cleanup including leading underscores on private/protected

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,3 +137,4 @@ ability to provide meaningful release notes.
 > git submodule init
 > git submodule update
 > ```
+> The later (update) command may need to be repeated occasionally after another contributor updates the version of reference code.

--- a/benchmark/JavaUnicodeInputStream.ts
+++ b/benchmark/JavaUnicodeInputStream.ts
@@ -28,125 +28,125 @@ const DIGIT_9 = '9'.charCodeAt(0);
  */
 export class JavaUnicodeInputStream implements CharStream {
 	@NotNull
-	private source: CharStream;
-	private escapeIndexes: IntegerList =  new IntegerList();
-	private escapeCharacters: IntegerList =  new IntegerList();
-	private escapeIndirectionLevels: IntegerList =  new IntegerList();
+	private _source: CharStream;
+	private _escapeIndexes: IntegerList =  new IntegerList();
+	private _escapeCharacters: IntegerList =  new IntegerList();
+	private _escapeIndirectionLevels: IntegerList =  new IntegerList();
 
-	private escapeListIndex: number = 0;
-	private range: number = 0;
-	private slashCount: number = 0;
+	private _escapeListIndex: number = 0;
+	private _range: number = 0;
+	private _slashCount: number = 0;
 
-	private la1: number;
+	private _la1: number;
 
 	 constructor(@NotNull source: CharStream)  {
 		if (source == null) {
 			throw new Error("NullPointerException: source");
 		}
 
-		this.source = source;
-		this.la1 = source.LA(1);
+		this._source = source;
+		this._la1 = source.LA(1);
 	}
 
 	@Override
 	get size(): number {
-		return this.source.size;
+		return this._source.size;
 	}
 
 	@Override
 	get index(): number {
-		return this.source.index;
+		return this._source.index;
 	}
 
 	@Override
 	get sourceName(): string {
-		return this.source.sourceName;
+		return this._source.sourceName;
 	}
 
 	@Override
 	getText(interval: Interval): string {
-		return this.source.getText(interval);
+		return this._source.getText(interval);
 	}
 
 	@Override
 	consume(): void {
-		if (this.la1 !== BACKSLASH) {
-			this.source.consume();
-			this.la1 = this.source.LA(1);
-			this.range = Math.max(this.range, this.source.index);
-			this.slashCount = 0;
+		if (this._la1 !== BACKSLASH) {
+			this._source.consume();
+			this._la1 = this._source.LA(1);
+			this._range = Math.max(this._range, this._source.index);
+			this._slashCount = 0;
 			return;
 		}
 
 		// make sure the next character has been processed
 		this.LA(1);
 
-		if (this.escapeListIndex >= this.escapeIndexes.size || this.escapeIndexes.get(this.escapeListIndex) !== this.index) {
-			this.source.consume();
-			this.slashCount++;
+		if (this._escapeListIndex >= this._escapeIndexes.size || this._escapeIndexes.get(this._escapeListIndex) !== this.index) {
+			this._source.consume();
+			this._slashCount++;
 		}
 		else {
-			let indirectionLevel: number =  this.escapeIndirectionLevels.get(this.escapeListIndex);
+			let indirectionLevel: number =  this._escapeIndirectionLevels.get(this._escapeListIndex);
 			for (let i = 0; i < 6 + indirectionLevel; i++) {
-				this.source.consume();
+				this._source.consume();
 			}
 
-			this.escapeListIndex++;
-			this.slashCount = 0;
+			this._escapeListIndex++;
+			this._slashCount = 0;
 		}
 
-		this.la1 = this.source.LA(1);
-		assert(this.range >= this.index);
+		this._la1 = this._source.LA(1);
+		assert(this._range >= this.index);
 	}
 
 	@Override
 	LA(i: number): number {
-		if (i === 1 && this.la1 !== BACKSLASH) {
-			return this.la1;
+		if (i === 1 && this._la1 !== BACKSLASH) {
+			return this._la1;
 		}
 
 		if (i <= 0) {
 			let desiredIndex: number = this.index + i;
-			for (let j = this.escapeListIndex - 1; j >= 0; j--) {
-				if (this.escapeIndexes.get(j) + 6 + this.escapeIndirectionLevels.get(j) > desiredIndex) {
-					desiredIndex -= 5 + this.escapeIndirectionLevels.get(j);
+			for (let j = this._escapeListIndex - 1; j >= 0; j--) {
+				if (this._escapeIndexes.get(j) + 6 + this._escapeIndirectionLevels.get(j) > desiredIndex) {
+					desiredIndex -= 5 + this._escapeIndirectionLevels.get(j);
 				}
 
-				if (this.escapeIndexes.get(j) === desiredIndex) {
-					return this.escapeCharacters.get(j);
+				if (this._escapeIndexes.get(j) === desiredIndex) {
+					return this._escapeCharacters.get(j);
 				}
 			}
 
-			return this.source.LA(desiredIndex - this.index);
+			return this._source.LA(desiredIndex - this.index);
 		}
 		else {
 			let desiredIndex: number =  this.index + i - 1;
-			for (let j = this.escapeListIndex; j < this.escapeIndexes.size; j++) {
-				if (this.escapeIndexes.get(j) === desiredIndex) {
-					return this.escapeCharacters.get(j);
+			for (let j = this._escapeListIndex; j < this._escapeIndexes.size; j++) {
+				if (this._escapeIndexes.get(j) === desiredIndex) {
+					return this._escapeCharacters.get(j);
 				}
-				else if (this.escapeIndexes.get(j) < desiredIndex) {
-					desiredIndex += 5 + this.escapeIndirectionLevels.get(j);
+				else if (this._escapeIndexes.get(j) < desiredIndex) {
+					desiredIndex += 5 + this._escapeIndirectionLevels.get(j);
 				}
 				else {
-					return this.source.LA(desiredIndex - this.index + 1);
+					return this._source.LA(desiredIndex - this.index + 1);
 				}
 			}
 
 			let currentIndex: number[] =  [this.index];
-			let slashCountPtr: number[] =  [this.slashCount];
+			let slashCountPtr: number[] =  [this._slashCount];
 			let indirectionLevelPtr: number[] =  [0];
 			for (let j = 0; j < i; j++) {
 				let previousIndex: number =  currentIndex[0];
-				let c: number = this.readCharAt(currentIndex, slashCountPtr, indirectionLevelPtr);
-				if (currentIndex[0] > this.range) {
+				let c: number = this._readCharAt(currentIndex, slashCountPtr, indirectionLevelPtr);
+				if (currentIndex[0] > this._range) {
 					if (currentIndex[0] - previousIndex > 1) {
-						this.escapeIndexes.add(previousIndex);
-						this.escapeCharacters.add(c);
-						this.escapeIndirectionLevels.add(indirectionLevelPtr[0]);
+						this._escapeIndexes.add(previousIndex);
+						this._escapeCharacters.add(c);
+						this._escapeIndirectionLevels.add(indirectionLevelPtr[0]);
 					}
 
-					this.range = currentIndex[0];
+					this._range = currentIndex[0];
 				}
 
 				if (j === i - 1) {
@@ -160,41 +160,41 @@ export class JavaUnicodeInputStream implements CharStream {
 
 	@Override
 	mark(): number {
-		return this.source.mark();
+		return this._source.mark();
 	}
 
 	@Override
 	release(marker: number): void {
-		this.source.release(marker);
+		this._source.release(marker);
 	}
 
 	@Override
 	seek(index: number): void {
-		if (index > this.range) {
+		if (index > this._range) {
 			throw new Error("UnsupportedOperationException");
 		}
 
-		this.source.seek(index);
-		this.la1 = this.source.LA(1);
+		this._source.seek(index);
+		this._la1 = this._source.LA(1);
 
-		this.slashCount = 0;
-		while (this.source.LA(-this.slashCount - 1) === BACKSLASH) {
-			this.slashCount++;
+		this._slashCount = 0;
+		while (this._source.LA(-this._slashCount - 1) === BACKSLASH) {
+			this._slashCount++;
 		}
 
-		this.escapeListIndex = this.escapeIndexes.binarySearch(this.source.index);
-		if (this.escapeListIndex < 0) {
-			this.escapeListIndex = -this.escapeListIndex - 1;
+		this._escapeListIndex = this._escapeIndexes.binarySearch(this._source.index);
+		if (this._escapeListIndex < 0) {
+			this._escapeListIndex = -this._escapeListIndex - 1;
 		}
 	}
 
-	private static isHexDigit(c: number): boolean {
+	private static _isHexDigit(c: number): boolean {
 		return c >= DIGIT_0 && c <= DIGIT_9
 			|| c >= LOWER_A && c <= LOWER_F
 			|| c >= UPPER_A && c <= UPPER_F;
 	}
 
-	private static hexValue(c: number): number {
+	private static _hexValue(c: number): number {
 		if (c >= DIGIT_0 && c <= DIGIT_9) {
 			return c - DIGIT_0;
 		}
@@ -210,35 +210,35 @@ export class JavaUnicodeInputStream implements CharStream {
 		throw new Error("IllegalArgumentException: c");
 	}
 
-	private readCharAt(nextIndexPtr: number[], slashCountPtr: number[], indirectionLevelPtr: number[]): number {
+	private _readCharAt(nextIndexPtr: number[], slashCountPtr: number[], indirectionLevelPtr: number[]): number {
 		assert(nextIndexPtr != null && nextIndexPtr.length === 1);
 		assert(slashCountPtr != null && slashCountPtr.length === 1);
 		assert(indirectionLevelPtr != null && indirectionLevelPtr.length === 1);
 
 		let blockUnicodeEscape: boolean =  (slashCountPtr[0] % 2) !== 0;
 
-		let c0: number = this.source.LA(nextIndexPtr[0] - this.index + 1);
+		let c0: number = this._source.LA(nextIndexPtr[0] - this.index + 1);
 		if (c0 === BACKSLASH) {
 			slashCountPtr[0]++;
 
 			if (!blockUnicodeEscape) {
-				let c1: number =  this.source.LA(nextIndexPtr[0] - this.index + 2);
+				let c1: number =  this._source.LA(nextIndexPtr[0] - this.index + 2);
 				if (c1 === LOWER_U) {
-					let c2: number =  this.source.LA(nextIndexPtr[0] - this.index + 3);
+					let c2: number =  this._source.LA(nextIndexPtr[0] - this.index + 3);
 					indirectionLevelPtr[0] = 0;
 					while (c2 === LOWER_U) {
 						indirectionLevelPtr[0]++;
-						c2 = this.source.LA(nextIndexPtr[0] - this.index + 3 + indirectionLevelPtr[0]);
+						c2 = this._source.LA(nextIndexPtr[0] - this.index + 3 + indirectionLevelPtr[0]);
 					}
 
-					let c3: number =  this.source.LA(nextIndexPtr[0] - this.index + 4 + indirectionLevelPtr[0]);
-					let c4: number =  this.source.LA(nextIndexPtr[0] - this.index + 5 + indirectionLevelPtr[0]);
-					let c5: number =  this.source.LA(nextIndexPtr[0] - this.index + 6 + indirectionLevelPtr[0]);
-					if (JavaUnicodeInputStream.isHexDigit(c2) && JavaUnicodeInputStream.isHexDigit(c3) && JavaUnicodeInputStream.isHexDigit(c4) && JavaUnicodeInputStream.isHexDigit(c5)) {
-						let value: number =  JavaUnicodeInputStream.hexValue(c2);
-						value = (value << 4) + JavaUnicodeInputStream.hexValue(c3);
-						value = (value << 4) + JavaUnicodeInputStream.hexValue(c4);
-						value = (value << 4) + JavaUnicodeInputStream.hexValue(c5);
+					let c3: number =  this._source.LA(nextIndexPtr[0] - this.index + 4 + indirectionLevelPtr[0]);
+					let c4: number =  this._source.LA(nextIndexPtr[0] - this.index + 5 + indirectionLevelPtr[0]);
+					let c5: number =  this._source.LA(nextIndexPtr[0] - this.index + 6 + indirectionLevelPtr[0]);
+					if (JavaUnicodeInputStream._isHexDigit(c2) && JavaUnicodeInputStream._isHexDigit(c3) && JavaUnicodeInputStream._isHexDigit(c4) && JavaUnicodeInputStream._isHexDigit(c5)) {
+						let value: number =  JavaUnicodeInputStream._hexValue(c2);
+						value = (value << 4) + JavaUnicodeInputStream._hexValue(c3);
+						value = (value << 4) + JavaUnicodeInputStream._hexValue(c4);
+						value = (value << 4) + JavaUnicodeInputStream._hexValue(c5);
 
 						nextIndexPtr[0] += 6 + indirectionLevelPtr[0];
 						slashCountPtr[0] = 0;

--- a/benchmark/TestPerformance.ts
+++ b/benchmark/TestPerformance.ts
@@ -1582,15 +1582,15 @@ class StatisticsLexerATNSimulator extends LexerATNSimulator {
 	}
 
 	@Override
-	protected getExistingTargetState(s: DFAState, t: number): DFAState | undefined {
+	protected _getExistingTargetState(s: DFAState, t: number): DFAState | undefined {
 		this.totalTransitions++;
-		return super.getExistingTargetState(s, t);
+		return super._getExistingTargetState(s, t);
 	}
 
 	@Override
-	protected computeTargetState(input: CharStream, s: DFAState, t: number): DFAState {
+	protected _computeTargetState(input: CharStream, s: DFAState, t: number): DFAState {
 		this.computedTransitions++;
-		return super.computeTargetState(input, s, t);
+		return super._computeTargetState(input, s, t);
 	}
 }
 
@@ -1638,26 +1638,26 @@ class StatisticsParserATNSimulator extends ParserATNSimulator {
 	}
 
 	@Override
-	protected getExistingTargetState(previousD: DFAState, t: number): DFAState | undefined {
+	protected _getExistingTargetState(previousD: DFAState, t: number): DFAState | undefined {
 		this.totalTransitions[this.decision]++;
-		return super.getExistingTargetState(previousD, t);
+		return super._getExistingTargetState(previousD, t);
 	}
 
 	@Override
-	protected computeTargetState(dfa: DFA, s: DFAState, remainingGlobalContext: ParserRuleContext, t: number, useContext: boolean, contextCache: PredictionContextCache): [DFAState, ParserRuleContext | undefined] {
+	protected _computeTargetState(dfa: DFA, s: DFAState, remainingGlobalContext: ParserRuleContext, t: number, useContext: boolean, contextCache: PredictionContextCache): [DFAState, ParserRuleContext | undefined] {
 		this.computedTransitions[this.decision]++;
-		return super.computeTargetState(dfa, s, remainingGlobalContext, t, useContext, contextCache);
+		return super._computeTargetState(dfa, s, remainingGlobalContext, t, useContext, contextCache);
 	}
 
 	@Override
-	protected computeReachSet(dfa: DFA, previous: SimulatorState, t: number, contextCache: PredictionContextCache): SimulatorState | undefined {
+	protected _computeReachSet(dfa: DFA, previous: SimulatorState, t: number, contextCache: PredictionContextCache): SimulatorState | undefined {
 		if (previous.useContext) {
 			this.totalTransitions[this.decision]++;
 			this.computedTransitions[this.decision]++;
 			this.fullContextTransitions[this.decision]++;
 		}
 
-		return super.computeReachSet(dfa, previous, t, contextCache);
+		return super._computeReachSet(dfa, previous, t, contextCache);
 	}
 }
 
@@ -1708,9 +1708,9 @@ class SummarizingDiagnosticErrorListener extends DiagnosticErrorListener {
 	@Override
 	reportAmbiguity(recognizer: Parser, dfa: DFA, startIndex: number, stopIndex: number, exact: boolean, ambigAlts: BitSet, configs: ATNConfigSet): void {
 		if (TestPerformance.COMPUTE_TRANSITION_STATS && TestPerformance.DETAILED_DFA_STATE_STATS) {
-			let sllPredictions: BitSet =  this.getConflictingAlts(this._sllConflict, this._sllConfigs);
+			let sllPredictions: BitSet =  this._getConflictingAlts(this._sllConflict, this._sllConfigs);
 			let sllPrediction: number =  sllPredictions.nextSetBit(0);
-			let llPredictions: BitSet =  this.getConflictingAlts(ambigAlts, configs);
+			let llPredictions: BitSet =  this._getConflictingAlts(ambigAlts, configs);
 			let llPrediction: number =  llPredictions.cardinality() === 0 ? ATN.INVALID_ALT_NUMBER : llPredictions.nextSetBit(0);
 			if (sllPrediction !== llPrediction) {
 				(<StatisticsParserATNSimulator>recognizer.interpreter).nonSll[dfa.decision]++;
@@ -1740,14 +1740,14 @@ class SummarizingDiagnosticErrorListener extends DiagnosticErrorListener {
 		let decision: number =  dfa.decision;
 		let rule: string =  recognizer.ruleNames[dfa.atnStartState.ruleIndex];
 		let input: string =  recognizer.inputStream.getText(Interval.of(startIndex, stopIndex));
-		let representedAlts: BitSet =  this.getConflictingAlts(conflictingAlts, conflictState.s0.configs);
+		let representedAlts: BitSet =  this._getConflictingAlts(conflictingAlts, conflictState.s0.configs);
 		recognizer.notifyErrorListeners(`reportAttemptingFullContext d=${decision} (${rule}), input='${input}', viable=${representedAlts}`);
 	}
 
 	@Override
 	reportContextSensitivity(recognizer: Parser, dfa: DFA, startIndex: number, stopIndex: number, prediction: number, acceptState: SimulatorState): void {
 		if (TestPerformance.COMPUTE_TRANSITION_STATS && TestPerformance.DETAILED_DFA_STATE_STATS) {
-			let sllPredictions: BitSet =  this.getConflictingAlts(this._sllConflict, this._sllConfigs);
+			let sllPredictions: BitSet =  this._getConflictingAlts(this._sllConflict, this._sllConfigs);
 			let sllPrediction: number =  sllPredictions.nextSetBit(0);
 			if (sllPrediction !== prediction) {
 				(<StatisticsParserATNSimulator>recognizer.interpreter).nonSll[dfa.decision]++;
@@ -1906,11 +1906,11 @@ class NonCachingLexerATNSimulator extends StatisticsLexerATNSimulator {
 		super(atn, recog);
 	}
 
-	protected addDFAEdge(/*@NotNull*/ p: DFAState, t: number, /*@NotNull*/ q: ATNConfigSet): DFAState;
-	protected addDFAEdge(/*@NotNull*/ p: DFAState, t: number, /*@NotNull*/ q: DFAState): void;
-	protected addDFAEdge(p: DFAState, t: number, q: ATNConfigSet | DFAState): DFAState | void {
+	protected _addDFAEdge(/*@NotNull*/ p: DFAState, t: number, /*@NotNull*/ q: ATNConfigSet): DFAState;
+	protected _addDFAEdge(/*@NotNull*/ p: DFAState, t: number, /*@NotNull*/ q: DFAState): void;
+	protected _addDFAEdge(p: DFAState, t: number, q: ATNConfigSet | DFAState): DFAState | void {
 		if (q instanceof ATNConfigSet) {
-			return super.addDFAEdge(p, t, q);
+			return super._addDFAEdge(p, t, q);
 		} else {
 			// do nothing
 		}
@@ -1923,7 +1923,7 @@ class NonCachingParserATNSimulator extends StatisticsParserATNSimulator {
 	}
 
 	@Override
-	protected setDFAEdge(p: DFAState, t: number, q: DFAState): void {
+	protected _setDFAEdge(p: DFAState, t: number, q: DFAState): void {
 		// Do not set the edge
 	}
 }
@@ -1999,7 +1999,7 @@ class CloneableANTLRFileStream extends ANTLRInputStream {
 	}
 
 	createCopy(): ANTLRInputStream {
-		let stream: ANTLRInputStream =  new ANTLRInputStream(this.data);
+		let stream: ANTLRInputStream =  new ANTLRInputStream(this._data);
 		stream.name = this.sourceName;
 		return stream;
 	}

--- a/src/ANTLRInputStream.ts
+++ b/src/ANTLRInputStream.ts
@@ -23,21 +23,21 @@ const INITIAL_BUFFER_SIZE: number = 1024;
 
 export class ANTLRInputStream implements CharStream {
 	/** The data being scanned */
-	protected data: string;
+	protected _data: string;
 
 	/** How many characters are actually in the buffer */
-	protected n: number;
+	protected _n: number;
 
 	/** 0..n-1 index into string of next char */
-	protected p: number = 0;
+	protected _p: number = 0;
 
 	/** What is name or source of this char stream? */
 	name?: string;
 
 	/** Copy data in string to a local char array */
 	constructor(input: string) {
-		this.data = input;
-		this.n = input.length;
+		this._data = input;
+		this._n = input.length;
 	}
 
 	/** Reset the stream so that it's in the same state it was
@@ -45,19 +45,19 @@ export class ANTLRInputStream implements CharStream {
 	 *  touched.
 	 */
 	reset(): void {
-		this.p = 0;
+		this._p = 0;
 	}
 
 	@Override
 	consume(): void {
-		if (this.p >= this.n) {
+		if (this._p >= this._n) {
 			assert(this.LA(1) === IntStream.EOF);
 			throw new Error("cannot consume EOF");
 		}
 
 		//System.out.println("prev p="+p+", c="+(char)data[p]);
-		if (this.p < this.n) {
-			this.p++;
+		if (this._p < this._n) {
+			this._p++;
 			//System.out.println("p moves to "+p+" (c='"+(char)data[p]+"')");
 		}
 	}
@@ -69,18 +69,18 @@ export class ANTLRInputStream implements CharStream {
 		}
 		if (i < 0) {
 			i++; // e.g., translate LA(-1) to use offset i=0; then data[p+0-1]
-			if ((this.p + i - 1) < 0) {
+			if ((this._p + i - 1) < 0) {
 				return IntStream.EOF; // invalid; no char before first char
 			}
 		}
 
-		if ((this.p + i - 1) >= this.n) {
+		if ((this._p + i - 1) >= this._n) {
 			//System.out.println("char LA("+i+")=EOF; p="+p);
 			return IntStream.EOF;
 		}
 		//System.out.println("char LA("+i+")="+(char)data[p+i-1]+"; p="+p);
 		//System.out.println("LA("+i+"); p="+p+" n="+n+" data.length="+data.length);
-		return this.data.charCodeAt(this.p + i - 1);
+		return this._data.charCodeAt(this._p + i - 1);
 	}
 
 	LT(i: number): number {
@@ -93,12 +93,12 @@ export class ANTLRInputStream implements CharStream {
      */
 	@Override
 	get index(): number {
-		return this.p;
+		return this._p;
 	}
 
 	@Override
 	get size(): number {
-		return this.n;
+		return this._n;
 	}
 
 	/** mark/release do nothing; we have entire buffer */
@@ -116,13 +116,13 @@ export class ANTLRInputStream implements CharStream {
 	 */
 	@Override
 	seek(index: number): void {
-		if (index <= this.p) {
-			this.p = index; // just jump; don't update stream state (line, ...)
+		if (index <= this._p) {
+			this._p = index; // just jump; don't update stream state (line, ...)
 			return;
 		}
 		// seek forward, consume until p hits index or n (whichever comes first)
-		index = Math.min(index, this.n);
-		while (this.p < index) {
+		index = Math.min(index, this._n);
+		while (this._p < index) {
 			this.consume();
 		}
 	}
@@ -131,13 +131,13 @@ export class ANTLRInputStream implements CharStream {
 	getText(interval: Interval): string {
 		let start: number = interval.a;
 		let stop: number = interval.b;
-		if (stop >= this.n) stop = this.n - 1;
+		if (stop >= this._n) stop = this._n - 1;
 		let count: number = stop - start + 1;
-		if (start >= this.n) return "";
+		if (start >= this._n) return "";
 		// System.err.println("data: "+Arrays.toString(data)+", n="+n+
 		// 				   ", start="+start+
 		// 				   ", stop="+stop);
-		return this.data.substr(start, count);
+		return this._data.substr(start, count);
 	}
 
 	@Override
@@ -149,5 +149,5 @@ export class ANTLRInputStream implements CharStream {
 	}
 
 	@Override
-	toString() { return this.data; }
+	toString() { return this._data; }
 }

--- a/src/BufferedTokenStream.ts
+++ b/src/BufferedTokenStream.ts
@@ -164,7 +164,7 @@ export class BufferedTokenStream implements TokenStream {
 
 		for (let i = 0; i < n; i++) {
 			let t: Token = this.tokenSource.nextToken();
-			if (this.isWritableToken(t)) {
+			if (this._isWritableToken(t)) {
 				t.tokenIndex = this.tokens.length;
 			}
 
@@ -503,7 +503,7 @@ export class BufferedTokenStream implements TokenStream {
 	@NotNull
 	@Override
 	getTextFromRange(start: any, stop: any): string {
-		if (this.isToken(start) && this.isToken(stop)) {
+		if (this._isToken(start) && this._isToken(stop)) {
 			return this.getText(Interval.of(start.tokenIndex, stop.tokenIndex));
 		}
 
@@ -523,12 +523,12 @@ export class BufferedTokenStream implements TokenStream {
 	}
 
 	// TODO: Figure out a way to make this more flexible?
-	private isWritableToken(t: Token): t is WritableToken {
+	private _isWritableToken(t: Token): t is WritableToken {
 		return t instanceof CommonToken;
 	}
 
 	// TODO: Figure out a way to make this more flexible?
-	private isToken(t: any): t is Token {
+	private _isToken(t: any): t is Token {
 		return t instanceof CommonToken;
 	}
 }

--- a/src/CommonToken.ts
+++ b/src/CommonToken.ts
@@ -19,7 +19,7 @@ export class CommonToken implements WritableToken {
 	 * An empty {@link Tuple2} which is used as the default value of
 	 * {@link #source} for tokens that do not have a source.
 	 */
-	protected static readonly EMPTY_SOURCE: { source?: TokenSource, stream?: CharStream } =
+	protected static readonly _EMPTY_SOURCE: { source?: TokenSource, stream?: CharStream } =
 		{ source: undefined, stream: undefined };
 
 	/**
@@ -51,7 +51,7 @@ export class CommonToken implements WritableToken {
 	 * {@link Tuple2} containing these values.</p>
 	 */
 	@NotNull
-	protected source: { source?: TokenSource, stream?: CharStream };
+	protected _source: { source?: TokenSource, stream?: CharStream };
 
 	/**
 	 * This is the backing field for {@link #getText} when the token text is
@@ -64,24 +64,24 @@ export class CommonToken implements WritableToken {
 	/**
 	 * This is the backing field for `tokenIndex`.
 	 */
-	protected index: number = -1;
+	protected _index: number = -1;
 
 	/**
 	 * This is the backing field for `startIndex`.
 	 */
-	protected start: number;
+	protected _start: number;
 
 	/**
 	 * This is the backing field for `stopIndex`.
 	 */
 	private stop: number;
 
-	constructor(type: number, text?: string, @NotNull source: { source?: TokenSource, stream?: CharStream } = CommonToken.EMPTY_SOURCE, channel: number = Token.DEFAULT_CHANNEL, start: number = 0, stop: number = 0) {
+	constructor(type: number, text?: string, @NotNull source: { source?: TokenSource, stream?: CharStream } = CommonToken._EMPTY_SOURCE, channel: number = Token.DEFAULT_CHANNEL, start: number = 0, stop: number = 0) {
 		this._text = text;
 		this._type = type;
-		this.source = source;
+		this._source = source;
 		this._channel = channel;
-		this.start = start;
+		this._start = start;
 		this.stop = stop;
 		if (source.source != null) {
 			this._line = source.source.line;
@@ -103,17 +103,17 @@ export class CommonToken implements WritableToken {
 	 * @param oldToken The token to copy.
 	 */
 	static fromToken(@NotNull oldToken: Token): CommonToken {
-		let result: CommonToken = new CommonToken(oldToken.type, undefined, CommonToken.EMPTY_SOURCE, oldToken.channel, oldToken.startIndex, oldToken.stopIndex);
+		let result: CommonToken = new CommonToken(oldToken.type, undefined, CommonToken._EMPTY_SOURCE, oldToken.channel, oldToken.startIndex, oldToken.stopIndex);
 		result._line = oldToken.line;
-		result.index = oldToken.tokenIndex;
+		result._index = oldToken.tokenIndex;
 		result._charPositionInLine = oldToken.charPositionInLine;
 
 		if (oldToken instanceof CommonToken) {
 			result._text = oldToken.text;
-			result.source = oldToken.source;
+			result._source = oldToken._source;
 		} else {
 			result._text = oldToken.text;
-			result.source = { source: oldToken.tokenSource, stream: oldToken.inputStream };
+			result._source = { source: oldToken.tokenSource, stream: oldToken.inputStream };
 		}
 
 		return result;
@@ -141,8 +141,8 @@ export class CommonToken implements WritableToken {
 		}
 
 		let n: number = input.size;
-		if (this.start < n && this.stop < n) {
-			return input.getText(Interval.of(this.start, this.stop));
+		if (this._start < n && this.stop < n) {
+			return input.getText(Interval.of(this._start, this.stop));
 		} else {
 			return "<EOF>";
 		}
@@ -194,11 +194,11 @@ export class CommonToken implements WritableToken {
 
 	@Override
 	get startIndex(): number {
-		return this.start;
+		return this._start;
 	}
 
 	set startIndex(start: number) {
-		this.start = start;
+		this._start = start;
 	}
 
 	@Override
@@ -212,22 +212,22 @@ export class CommonToken implements WritableToken {
 
 	@Override
 	get tokenIndex(): number {
-		return this.index;
+		return this._index;
 	}
 
 	// @Override
 	set tokenIndex(index: number) {
-		this.index = index;
+		this._index = index;
 	}
 
 	@Override
 	get tokenSource(): TokenSource | undefined {
-		return this.source.source;
+		return this._source.source;
 	}
 
 	@Override
 	get inputStream(): CharStream | undefined {
-		return this.source.stream;
+		return this._source.stream;
 	}
 
 	toString(): string;
@@ -254,6 +254,6 @@ export class CommonToken implements WritableToken {
 			typeString = recognizer.vocabulary.getDisplayName(this._type);
 		}
 
-		return "[@" + this.tokenIndex + "," + this.start + ":" + this.stop + "='" + txt + "',<" + typeString + ">" + channelStr + "," + this._line + ":" + this.charPositionInLine + "]";
+		return "[@" + this.tokenIndex + "," + this._start + ":" + this.stop + "='" + txt + "',<" + typeString + ">" + channelStr + "," + this._line + ":" + this.charPositionInLine + "]";
 	}
 }

--- a/src/CommonTokenFactory.ts
+++ b/src/CommonTokenFactory.ts
@@ -32,7 +32,7 @@ export class CommonTokenFactory implements TokenFactory {
 	 * The default value is {@code false} to avoid the performance and memory
 	 * overhead of copying text for every token unless explicitly requested.</p>
 	 */
-	protected copyText: boolean;
+	protected _copyText: boolean;
 
 	/**
 	 * Constructs a {@link CommonTokenFactory} with the specified value for
@@ -45,7 +45,7 @@ export class CommonTokenFactory implements TokenFactory {
 	 * @param copyText The value for {@link #copyText}.
 	 */
 	constructor(copyText: boolean = false) {
-		this.copyText = copyText;
+		this._copyText = copyText;
 	}
 
 	@Override
@@ -62,7 +62,7 @@ export class CommonTokenFactory implements TokenFactory {
 		let t: CommonToken = new CommonToken(type, text, source, channel, start, stop);
 		t.line = line;
 		t.charPositionInLine = charPositionInLine;
-		if (text == null && this.copyText && source.stream != null) {
+		if (text == null && this._copyText && source.stream != null) {
 			t.text = source.stream.getText(Interval.of(start, stop));
 		}
 

--- a/src/CommonTokenStream.ts
+++ b/src/CommonTokenStream.ts
@@ -42,7 +42,7 @@ export class CommonTokenStream extends BufferedTokenStream {
 	 * The default value is {@link Token#DEFAULT_CHANNEL}, which matches the
 	 * default channel assigned to tokens created by the lexer.</p>
 	 */
-	protected channel: number;
+	protected _channel: number;
 
 	/**
 	 * Constructs a new {@link CommonTokenStream} using the specified token
@@ -56,26 +56,26 @@ export class CommonTokenStream extends BufferedTokenStream {
 	 */
 	constructor(@NotNull tokenSource: TokenSource, channel: number = Token.DEFAULT_CHANNEL) {
 		super(tokenSource);
-		this.channel = channel;
+		this._channel = channel;
 	}
 
 	@Override
-	protected adjustSeekIndex(i: number): number {
-		return this.nextTokenOnChannel(i, this.channel);
+	protected _adjustSeekIndex(i: number): number {
+		return this._nextTokenOnChannel(i, this._channel);
 	}
 
 	@Override
-	protected tryLB(k: number): Token | undefined {
-		if ((this.p - k) < 0) {
+	protected _tryLB(k: number): Token | undefined {
+		if ((this._p - k) < 0) {
 			return undefined;
 		}
 
-		let i: number = this.p;
+		let i: number = this._p;
 		let n: number = 1;
 		// find k good tokens looking backwards
 		while (n <= k && i > 0) {
 			// skip off-channel tokens
-			i = this.previousTokenOnChannel(i - 1, this.channel);
+			i = this._previousTokenOnChannel(i - 1, this._channel);
 			n++;
 		}
 
@@ -83,43 +83,43 @@ export class CommonTokenStream extends BufferedTokenStream {
 			return undefined;
 		}
 
-		return this.tokens[i];
+		return this._tokens[i];
 	}
 
 	@Override
 	tryLT(k: number): Token | undefined {
 		//System.out.println("enter LT("+k+")");
-		this.lazyInit();
+		this._lazyInit();
 		if (k === 0) {
 			throw new RangeError("0 is not a valid lookahead index");
 		}
 
 		if (k < 0) {
-			return this.tryLB(-k);
+			return this._tryLB(-k);
 		}
 
-		let i: number = this.p;
+		let i: number = this._p;
 		let n: number = 1; // we know tokens[p] is a good one
 		// find k good tokens
 		while (n < k) {
 			// skip off-channel tokens, but make sure to not look past EOF
-			if (this.sync(i + 1)) {
-				i = this.nextTokenOnChannel(i + 1, this.channel);
+			if (this._sync(i + 1)) {
+				i = this._nextTokenOnChannel(i + 1, this._channel);
 			}
 			n++;
 		}
 
 		//		if ( i>range ) range = i;
-		return this.tokens[i];
+		return this._tokens[i];
 	}
 
 	/** Count EOF just once. */
 	getNumberOfOnChannelTokens(): number {
 		let n: number = 0;
 		this.fill();
-		for (let i = 0; i < this.tokens.length; i++) {
-			let t: Token = this.tokens[i];
-			if (t.channel === this.channel) {
+		for (let i = 0; i < this._tokens.length; i++) {
+			let t: Token = this._tokens[i];
+			if (t.channel === this._channel) {
 				n++;
 			}
 

--- a/src/DiagnosticErrorListener.ts
+++ b/src/DiagnosticErrorListener.ts
@@ -47,8 +47,8 @@ export class DiagnosticErrorListener implements ParserErrorListener {
 	 * @param exactOnly {@code true} to report only exact ambiguities, otherwise
 	 * {@code false} to report all ambiguities.  Defaults to true.
 	 */
-	constructor(protected exactOnly: boolean = true) {
-		this.exactOnly = exactOnly;
+	constructor(protected _exactOnly: boolean = true) {
+		this._exactOnly = _exactOnly;
 	}
 
 	@Override
@@ -59,12 +59,12 @@ export class DiagnosticErrorListener implements ParserErrorListener {
 		exact: boolean,
 		ambigAlts: BitSet | undefined,
 		@NotNull configs: ATNConfigSet): void {
-		if (this.exactOnly && !exact) {
+		if (this._exactOnly && !exact) {
 			return;
 		}
 
-		let decision: string = this.getDecisionDescription(recognizer, dfa);
-		let conflictingAlts: BitSet = this.getConflictingAlts(ambigAlts, configs);
+		let decision: string = this._getDecisionDescription(recognizer, dfa);
+		let conflictingAlts: BitSet = this._getConflictingAlts(ambigAlts, configs);
 		let text: string = recognizer.inputStream.getText(Interval.of(startIndex, stopIndex));
 		let message: string = `reportAmbiguity d=${decision}: ambigAlts=${conflictingAlts}, input='${text}'`;
 		recognizer.notifyErrorListeners(message);
@@ -78,7 +78,7 @@ export class DiagnosticErrorListener implements ParserErrorListener {
 		conflictingAlts: BitSet | undefined,
 		@NotNull conflictState: SimulatorState): void {
 		let format: string = "reportAttemptingFullContext d=%s, input='%s'";
-		let decision: string = this.getDecisionDescription(recognizer, dfa);
+		let decision: string = this._getDecisionDescription(recognizer, dfa);
 		let text: string = recognizer.inputStream.getText(Interval.of(startIndex, stopIndex));
 		let message: string = `reportAttemptingFullContext d=${decision}, input='${text}'`;
 		recognizer.notifyErrorListeners(message);
@@ -92,13 +92,13 @@ export class DiagnosticErrorListener implements ParserErrorListener {
 		prediction: number,
 		@NotNull acceptState: SimulatorState): void {
 		let format: string = "reportContextSensitivity d=%s, input='%s'";
-		let decision: string = this.getDecisionDescription(recognizer, dfa);
+		let decision: string = this._getDecisionDescription(recognizer, dfa);
 		let text: string = recognizer.inputStream.getText(Interval.of(startIndex, stopIndex));
 		let message: string = `reportContextSensitivity d=${decision}, input='${text}'`;
 		recognizer.notifyErrorListeners(message);
 	}
 
-	protected getDecisionDescription(
+	protected _getDecisionDescription(
 		@NotNull recognizer: Parser,
 		@NotNull dfa: DFA): string {
 		let decision: number = dfa.decision;
@@ -129,7 +129,7 @@ export class DiagnosticErrorListener implements ParserErrorListener {
 	 * returns the set of alternatives represented in {@code configs}.
 	 */
 	@NotNull
-	protected getConflictingAlts(reportedAlts: BitSet | undefined, @NotNull configs: ATNConfigSet): BitSet {
+	protected _getConflictingAlts(reportedAlts: BitSet | undefined, @NotNull configs: ATNConfigSet): BitSet {
 		if (reportedAlts != null) {
 			return reportedAlts;
 		}

--- a/src/FailedPredicateException.ts
+++ b/src/FailedPredicateException.ts
@@ -21,7 +21,7 @@ import { NotNull } from "./Decorators";
 import { PredicateTransition } from './atn/PredicateTransition';
 
 export class FailedPredicateException extends RecognitionException {
-	//private static serialVersionUID: number =  5379330841495778709L;
+	//private static _serialVersionUID: number =  5379330841495778709L;
 
 	private _ruleIndex: number;
 	private _predicateIndex: number;
@@ -32,7 +32,7 @@ export class FailedPredicateException extends RecognitionException {
 			recognizer,
 			recognizer.inputStream,
 			recognizer.context,
-			FailedPredicateException.formatMessage(predicate, message));
+			FailedPredicateException._formatMessage(predicate, message));
 		let s: ATNState = recognizer.interpreter.atn.states[recognizer.state];
 
 		let trans = s.transition(0) as AbstractPredicateTransition;
@@ -62,7 +62,7 @@ export class FailedPredicateException extends RecognitionException {
 	}
 
 	@NotNull
-	private static formatMessage(predicate: string | undefined, message: string | undefined): string {
+	private static _formatMessage(predicate: string | undefined, message: string | undefined): string {
 		if (message) {
 			return message;
 		}

--- a/src/InputMismatchException.ts
+++ b/src/InputMismatchException.ts
@@ -13,7 +13,7 @@ import { NotNull } from "./Decorators";
 import { Parser } from "./Parser";
 
 export class InputMismatchException extends RecognitionException {
-	//private static serialVersionUID: number =  1532568338707443067L;
+	//private static _serialVersionUID: number =  1532568338707443067L;
 
 	constructor(@NotNull recognizer: Parser) {
 		super(recognizer, recognizer.inputStream, recognizer.context);

--- a/src/ListTokenSource.ts
+++ b/src/ListTokenSource.ts
@@ -24,7 +24,7 @@ export class ListTokenSource implements TokenSource {
 	/**
 	 * The wrapped collection of {@link Token} objects to return.
 	 */
-	protected tokens: Token[];
+	protected _tokens: Token[];
 
 	/**
 	 * The name of the input source. If this value is {@code null}, a call to
@@ -39,12 +39,12 @@ export class ListTokenSource implements TokenSource {
 	 * {@link #nextToken}. The end of the input is indicated by this value
 	 * being greater than or equal to the number of items in {@link #tokens}.
 	 */
-	protected i: number = 0;
+	protected _i: number = 0;
 
 	/**
 	 * This field caches the EOF token for the token source.
 	 */
-	protected eofToken?: Token;
+	protected _eofToken?: Token;
 
 	/**
 	 * This is the backing field for {@link #getTokenFactory} and
@@ -70,7 +70,7 @@ export class ListTokenSource implements TokenSource {
 			throw new Error("tokens cannot be null");
 		}
 
-		this.tokens = tokens;
+		this._tokens = tokens;
 		this._sourceName = sourceName;
 	}
 
@@ -79,14 +79,14 @@ export class ListTokenSource implements TokenSource {
 	 */
 	@Override
 	get charPositionInLine(): number {
-		if (this.i < this.tokens.length) {
-			return this.tokens[this.i].charPositionInLine;
-		} else if (this.eofToken != null) {
-			return this.eofToken.charPositionInLine;
-		} else if (this.tokens.length > 0) {
+		if (this._i < this._tokens.length) {
+			return this._tokens[this._i].charPositionInLine;
+		} else if (this._eofToken != null) {
+			return this._eofToken.charPositionInLine;
+		} else if (this._tokens.length > 0) {
 			// have to calculate the result from the line/column of the previous
 			// token, along with the text of the token.
-			let lastToken: Token = this.tokens[this.tokens.length - 1];
+			let lastToken: Token = this._tokens[this._tokens.length - 1];
 			let tokenText: string | undefined = lastToken.text;
 			if (tokenText != null) {
 				let lastNewLine: number = tokenText.lastIndexOf('\n');
@@ -108,29 +108,29 @@ export class ListTokenSource implements TokenSource {
 	 */
 	@Override
 	nextToken(): Token {
-		if (this.i >= this.tokens.length) {
-			if (this.eofToken == null) {
+		if (this._i >= this._tokens.length) {
+			if (this._eofToken == null) {
 				let start: number = -1;
-				if (this.tokens.length > 0) {
-					let previousStop: number = this.tokens[this.tokens.length - 1].stopIndex;
+				if (this._tokens.length > 0) {
+					let previousStop: number = this._tokens[this._tokens.length - 1].stopIndex;
 					if (previousStop !== -1) {
 						start = previousStop + 1;
 					}
 				}
 
 				let stop: number = Math.max(-1, start - 1);
-				this.eofToken = this._factory.create({ source: this, stream: this.inputStream }, Token.EOF, "EOF", Token.DEFAULT_CHANNEL, start, stop, this.line, this.charPositionInLine);
+				this._eofToken = this._factory.create({ source: this, stream: this.inputStream }, Token.EOF, "EOF", Token.DEFAULT_CHANNEL, start, stop, this.line, this.charPositionInLine);
 			}
 
-			return this.eofToken;
+			return this._eofToken;
 		}
 
-		let t: Token = this.tokens[this.i];
-		if (this.i === this.tokens.length - 1 && t.type === Token.EOF) {
-			this.eofToken = t;
+		let t: Token = this._tokens[this._i];
+		if (this._i === this._tokens.length - 1 && t.type === Token.EOF) {
+			this._eofToken = t;
 		}
 
-		this.i++;
+		this._i++;
 		return t;
 	}
 
@@ -139,14 +139,14 @@ export class ListTokenSource implements TokenSource {
 	 */
 	@Override
 	get line(): number {
-		if (this.i < this.tokens.length) {
-			return this.tokens[this.i].line;
-		} else if (this.eofToken != null) {
-			return this.eofToken.line;
-		} else if (this.tokens.length > 0) {
+		if (this._i < this._tokens.length) {
+			return this._tokens[this._i].line;
+		} else if (this._eofToken != null) {
+			return this._eofToken.line;
+		} else if (this._tokens.length > 0) {
 			// have to calculate the result from the line/column of the previous
 			// token, along with the text of the token.
-			let lastToken: Token = this.tokens[this.tokens.length - 1];
+			let lastToken: Token = this._tokens[this._tokens.length - 1];
 			let line: number = lastToken.line;
 
 			let tokenText: string | undefined = lastToken.text;
@@ -172,12 +172,12 @@ export class ListTokenSource implements TokenSource {
 	 */
 	@Override
 	get inputStream(): CharStream | undefined {
-		if (this.i < this.tokens.length) {
-			return this.tokens[this.i].inputStream;
-		} else if (this.eofToken != null) {
-			return this.eofToken.inputStream;
-		} else if (this.tokens.length > 0) {
-			return this.tokens[this.tokens.length - 1].inputStream;
+		if (this._i < this._tokens.length) {
+			return this._tokens[this._i].inputStream;
+		} else if (this._eofToken != null) {
+			return this._eofToken.inputStream;
+		} else if (this._tokens.length > 0) {
+			return this._tokens[this._tokens.length - 1].inputStream;
 		}
 
 		// no input stream information is available

--- a/src/NoViableAltException.ts
+++ b/src/NoViableAltException.ts
@@ -22,7 +22,7 @@ import { IntStream } from "./IntStream";
 import { NotNull } from "./Decorators";
 
 export class NoViableAltException extends RecognitionException {
-	//private static serialVersionUID: number =  5096000008992867052L;
+	//private static _serialVersionUID: number =  5096000008992867052L;
 
 	/** Which configurations did we try at input.index that couldn't match input.LT(1)? */
 	private _deadEndConfigs?: ATNConfigSet;

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -43,19 +43,19 @@ import { TokenSource } from './TokenSource';
 import { TokenStream } from './TokenStream';
 
 class TraceListener implements ParseTreeListener {
-	constructor(private ruleNames: string[], private tokenStream: TokenStream) {
+	constructor(private _ruleNames: string[], private _tokenStream: TokenStream) {
 	}
 
 	@Override
 	enterEveryRule(ctx: ParserRuleContext): void {
-		console.log("enter   " + this.ruleNames[ctx.ruleIndex] +
-			", LT(1)=" + this.tokenStream.LT(1).text);
+		console.log("enter   " + this._ruleNames[ctx.ruleIndex] +
+			", LT(1)=" + this._tokenStream.LT(1).text);
 	}
 
 	@Override
 	exitEveryRule(ctx: ParserRuleContext): void {
-		console.log("exit    " + this.ruleNames[ctx.ruleIndex] +
-			", LT(1)=" + this.tokenStream.LT(1).text);
+		console.log("exit    " + this._ruleNames[ctx.ruleIndex] +
+			", LT(1)=" + this._tokenStream.LT(1).text);
 	}
 
 	@Override
@@ -66,7 +66,7 @@ class TraceListener implements ParseTreeListener {
 	visitTerminal(node: TerminalNode): void {
 		let parent = node.parent!.ruleContext;
 		let token: Token = node.symbol;
-		console.log("consume " + token + " rule " + this.ruleNames[parent.ruleIndex]);
+		console.log("consume " + token + " rule " + this._ruleNames[parent.ruleIndex]);
 	}
 }
 
@@ -78,7 +78,7 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 	 *
 	 * @see ATNDeserializationOptions.isGenerateRuleBypassTransitions
 	 */
-	private static readonly bypassAltsAtnCache = new Map<string, ATN>();
+	private static readonly _bypassAltsAtnCache = new Map<string, ATN>();
 
 	/**
 	 * The error handling strategy for the parser. The default value is a new
@@ -402,12 +402,12 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 			throw new Error("The current parser does not support an ATN with bypass alternatives.");
 		}
 
-		let result = Parser.bypassAltsAtnCache.get(serializedAtn);
+		let result = Parser._bypassAltsAtnCache.get(serializedAtn);
 		if (result == null) {
 			let deserializationOptions: ATNDeserializationOptions = new ATNDeserializationOptions();
 			deserializationOptions.isGenerateRuleBypassTransitions = true;
 			result = new ATNDeserializer(deserializationOptions).deserialize(Utils.toCharArray(serializedAtn));
-			Parser.bypassAltsAtnCache.set(serializedAtn, result);
+			Parser._bypassAltsAtnCache.set(serializedAtn, result);
 		}
 
 		return result;

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -139,7 +139,7 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 	protected _syntaxErrors: number = 0;
 
 	/** Indicates parser has match()ed EOF token. See {@link #exitRule()}. */
-	protected matchedEOF: boolean = false;
+	protected _matchedEOF: boolean = false;
 
 	constructor(input: TokenStream) {
 		super();
@@ -159,7 +159,7 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 		this._errHandler.reset(this);
 		this._ctx = <any>undefined;
 		this._syntaxErrors = 0;
-		this.matchedEOF = false;
+		this._matchedEOF = false;
 		this.isTrace = false;
 		this._precedenceStack.clear();
 		this._precedenceStack.push(0);
@@ -192,7 +192,7 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 		let t: Token = this.currentToken;
 		if (t.type === ttype) {
 			if (ttype === Token.EOF) {
-				this.matchedEOF = true;
+				this._matchedEOF = true;
 			}
 			this._errHandler.reportMatch(this);
 			this.consume();
@@ -348,7 +348,7 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 	 *
 	 * @see #addParseListener
 	 */
-	protected triggerEnterRuleEvent(): void {
+	protected _triggerEnterRuleEvent(): void {
 		for (let listener of this._parseListeners) {
 			if (listener.enterEveryRule) {
 				listener.enterEveryRule(this._ctx);
@@ -363,7 +363,7 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 	 *
 	 * @see #addParseListener
 	 */
-	protected triggerExitRuleEvent(): void {
+	protected _triggerExitRuleEvent(): void {
 		// reverse order walk of listeners
 		for (let i = this._parseListeners.length - 1; i >= 0; i--) {
 			let listener: ParseTreeListener = this._parseListeners[i];
@@ -555,7 +555,7 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 		return o;
 	}
 
-	protected addContextToParseTree(): void {
+	protected _addContextToParseTree(): void {
 		let parent = this._ctx._parent as ParserRuleContext | undefined;
 		// add current context to parent if we have a parent
 		if (parent != null) {
@@ -571,8 +571,8 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 		this.state = state;
 		this._ctx = localctx;
 		this._ctx._start = this._input.LT(1);
-		if (this._buildParseTrees) this.addContextToParseTree();
-		this.triggerEnterRuleEvent();
+		if (this._buildParseTrees) this._addContextToParseTree();
+		this._triggerEnterRuleEvent();
 	}
 
 	enterLeftFactoredRule(localctx: ParserRuleContext, state: number, ruleIndex: number): void {
@@ -587,14 +587,14 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 		this._ctx = localctx;
 		this._ctx._start = this._input.LT(1);
 		if (this._buildParseTrees) {
-			this.addContextToParseTree();
+			this._addContextToParseTree();
 		}
 
-		this.triggerEnterRuleEvent();
+		this._triggerEnterRuleEvent();
 	}
 
 	exitRule(): void {
-		if (this.matchedEOF) {
+		if (this._matchedEOF) {
 			// if we have matched EOF, it cannot consume past EOF so we use LT(1) here
 			this._ctx._stop = this._input.LT(1); // LT(1) will be end of file
 		}
@@ -602,7 +602,7 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 			this._ctx._stop = this._input.tryLT(-1); // stop node is what we just matched
 		}
 		// trigger event on _ctx, before it reverts to parent
-		this.triggerExitRuleEvent();
+		this._triggerExitRuleEvent();
 		this.state = this._ctx.invokingState;
 		this._ctx = this._ctx._parent as ParserRuleContext;
 	}
@@ -640,7 +640,7 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 		this._precedenceStack.push(precedence);
 		this._ctx = localctx;
 		this._ctx._start = this._input.LT(1);
-		this.triggerEnterRuleEvent(); // simulates rule entry for left-recursive rules
+		this._triggerEnterRuleEvent(); // simulates rule entry for left-recursive rules
 	}
 
 	/** Like {@link #enterRule} but for recursive rules.
@@ -658,7 +658,7 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 			this._ctx.addChild(previous);
 		}
 
-		this.triggerEnterRuleEvent(); // simulates rule entry for left-recursive rules
+		this._triggerEnterRuleEvent(); // simulates rule entry for left-recursive rules
 	}
 
 	unrollRecursionContexts(_parentctx: ParserRuleContext): void {
@@ -669,7 +669,7 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 		// unroll so _ctx is as it was before call to recursive method
 		if (this._parseListeners.length > 0) {
 			while (this._ctx !== _parentctx) {
-				this.triggerExitRuleEvent();
+				this._triggerExitRuleEvent();
 				this._ctx = this._ctx._parent as ParserRuleContext;
 			}
 		}
@@ -762,7 +762,7 @@ export abstract class Parser extends Recognizer<Token, ParserATNSimulator> {
 	}
 
 	get isMatchedEOF(): boolean {
-		return this.matchedEOF;
+		return this._matchedEOF;
 	}
 
 	/**

--- a/src/ParserRuleContext.ts
+++ b/src/ParserRuleContext.ts
@@ -38,7 +38,7 @@ import { Token } from "./Token";
  *  satisfy the superclass interface.
  */
 export class ParserRuleContext extends RuleContext {
-	private static readonly EMPTY: ParserRuleContext = new ParserRuleContext();
+	private static readonly _EMPTY: ParserRuleContext = new ParserRuleContext();
 
 	/** If we are debugging or building a parse tree for a visitor,
 	 *  we need to track all of the tokens and rule invocations associated
@@ -88,7 +88,7 @@ export class ParserRuleContext extends RuleContext {
 	}
 
 	static emptyContext(): ParserRuleContext {
-		return ParserRuleContext.EMPTY;
+		return ParserRuleContext._EMPTY;
 	}
 
 	/**

--- a/src/ProxyErrorListener.ts
+++ b/src/ProxyErrorListener.ts
@@ -18,14 +18,14 @@ import { Override, NotNull } from "./Decorators";
  */
 export class ProxyErrorListener<Symbol, TListener extends ANTLRErrorListener<Symbol>> implements ANTLRErrorListener<Symbol> {
 
-	constructor(private delegates: TListener[]) {
-		if (!delegates) {
+	constructor(private _delegates: TListener[]) {
+		if (!_delegates) {
 			throw new Error("Invalid delegates");
 		}
 	}
 
 	protected getDelegates(): ReadonlyArray<TListener> {
-		return this.delegates;
+		return this._delegates;
 	}
 
 	@Override
@@ -36,7 +36,7 @@ export class ProxyErrorListener<Symbol, TListener extends ANTLRErrorListener<Sym
 		charPositionInLine: number,
 		@NotNull msg: string,
 		e: RecognitionException | undefined): void {
-		this.delegates.forEach(listener => {
+		this._delegates.forEach(listener => {
 			if (listener.syntaxError) {
 				listener.syntaxError(recognizer, offendingSymbol, line, charPositionInLine, msg, e);
 			}

--- a/src/ProxyErrorListener.ts
+++ b/src/ProxyErrorListener.ts
@@ -24,7 +24,7 @@ export class ProxyErrorListener<Symbol, TListener extends ANTLRErrorListener<Sym
 		}
 	}
 
-	protected getDelegates(): ReadonlyArray<TListener> {
+	protected _getDelegates(): ReadonlyArray<TListener> {
 		return this._delegates;
 	}
 

--- a/src/ProxyParserErrorListener.ts
+++ b/src/ProxyParserErrorListener.ts
@@ -36,7 +36,7 @@ export class ProxyParserErrorListener extends ProxyErrorListener<Token, ParserEr
 		exact: boolean,
 		ambigAlts: BitSet,
 		configs: ATNConfigSet): void {
-		this.getDelegates()
+		this._getDelegates()
 			.forEach(listener => {
 				if (listener.reportAmbiguity) {
 					listener.reportAmbiguity(
@@ -59,7 +59,7 @@ export class ProxyParserErrorListener extends ProxyErrorListener<Token, ParserEr
 		stopIndex: number,
 		conflictingAlts: BitSet,
 		conflictState: SimulatorState): void {
-		this.getDelegates()
+		this._getDelegates()
 			.forEach(listener => {
 				if (listener.reportAttemptingFullContext) {
 					listener.reportAttemptingFullContext(
@@ -80,7 +80,7 @@ export class ProxyParserErrorListener extends ProxyErrorListener<Token, ParserEr
 		stopIndex: number,
 		prediction: number,
 		acceptState: SimulatorState): void {
-		this.getDelegates()
+		this._getDelegates()
 			.forEach(listener => {
 				if (listener.reportContextSensitivity) {
 					listener.reportContextSensitivity(

--- a/src/RecognitionException.ts
+++ b/src/RecognitionException.ts
@@ -22,21 +22,21 @@ import { Token } from "./Token";
  *  and what kind of problem occurred.
  */
 export class RecognitionException extends Error {
-	// private static serialVersionUID: number =  -3861826954750022374L;
+	// private static _serialVersionUID: number =  -3861826954750022374L;
 
 	/** The {@link Recognizer} where this exception originated. */
 	private _recognizer?: Recognizer<any, any>;
 
-	private ctx?: RuleContext;
+	private _ctx?: RuleContext;
 
-	private input?: IntStream;
+	private _input?: IntStream;
 
 	/**
 	 * The current {@link Token} when an error occurred. Since not all streams
 	 * support accessing symbols by index, we have to track the {@link Token}
 	 * instance itself.
 	 */
-	private offendingToken?: Token;
+	private _offendingToken?: Token;
 
 	private _offendingState: number = -1;
 
@@ -60,8 +60,8 @@ export class RecognitionException extends Error {
 		super(message);
 
 		this._recognizer = recognizer;
-		this.input = input;
-		this.ctx = ctx;
+		this._input = input;
+		this._ctx = ctx;
 		if (recognizer) this._offendingState = recognizer.state;
 	}
 
@@ -94,7 +94,7 @@ export class RecognitionException extends Error {
 	 */
 	get expectedTokens(): IntervalSet | undefined {
 		if (this._recognizer) {
-			return this._recognizer.atn.getExpectedTokens(this._offendingState, this.ctx);
+			return this._recognizer.atn.getExpectedTokens(this._offendingState, this._ctx);
 		}
 		return undefined;
 	}
@@ -108,7 +108,7 @@ export class RecognitionException extends Error {
 	 * If the context is not available, this method returns {@code null}.
 	 */
 	get context(): RuleContext | undefined {
-		return this.ctx;
+		return this._ctx;
 	}
 
 	/**
@@ -123,19 +123,19 @@ export class RecognitionException extends Error {
 	 */
 
 	get inputStream(): IntStream | undefined {
-		return this.input;
+		return this._input;
 	}
 
 	getOffendingToken(recognizer?: Recognizer<Token, any>): Token | undefined {
 		if (recognizer && recognizer !== this._recognizer) return undefined;
-		return this.offendingToken;
+		return this._offendingToken;
 	}
 
 	protected setOffendingToken<Symbol extends Token>(
 		recognizer: Recognizer<Symbol, any>,
 		offendingToken?: Symbol): void {
 		if (recognizer === this._recognizer) {
-			this.offendingToken = offendingToken;
+			this._offendingToken = offendingToken;
 		}
 	}
 

--- a/src/Recognizer.ts
+++ b/src/Recognizer.ts
@@ -23,9 +23,9 @@ import * as Utils from './misc/Utils';
 export abstract class Recognizer<Symbol, ATNInterpreter extends ATNSimulator> {
 	static readonly EOF: number = -1;
 
-	private static tokenTypeMapCache =
+	private static _tokenTypeMapCache =
 	 	new WeakMap<Vocabulary, ReadonlyMap<string, number>>();
-	private static ruleIndexMapCache =
+	private static _ruleIndexMapCache =
 	 	new WeakMap<string[], ReadonlyMap<string, number>>();
 
 	@SuppressWarnings("serial")
@@ -54,7 +54,7 @@ export abstract class Recognizer<Symbol, ATNInterpreter extends ATNSimulator> {
 	@NotNull
 	getTokenTypeMap(): ReadonlyMap<string, number> {
 		let vocabulary: Vocabulary = this.vocabulary;
-		let result = Recognizer.tokenTypeMapCache.get(vocabulary);
+		let result = Recognizer._tokenTypeMapCache.get(vocabulary);
 		if (result == null) {
 			let intermediateResult = new Map<string, number>();
 			for (let i = 0; i <= this.atn.maxTokenType; i++) {
@@ -71,7 +71,7 @@ export abstract class Recognizer<Symbol, ATNInterpreter extends ATNSimulator> {
 
 			intermediateResult.set("EOF", Token.EOF);
 			result = Object.freeze(intermediateResult);
-			Recognizer.tokenTypeMapCache.set(vocabulary, result);
+			Recognizer._tokenTypeMapCache.set(vocabulary, result);
 		}
 
 		return result;
@@ -89,10 +89,10 @@ export abstract class Recognizer<Symbol, ATNInterpreter extends ATNSimulator> {
 			throw new Error("The current recognizer does not provide a list of rule names.");
 		}
 
-		let result: ReadonlyMap<string, number> | undefined = Recognizer.ruleIndexMapCache.get(ruleNames);
+		let result: ReadonlyMap<string, number> | undefined = Recognizer._ruleIndexMapCache.get(ruleNames);
 		if (result == null) {
 			result = Object.freeze(Utils.toMap(ruleNames));
-			Recognizer.ruleIndexMapCache.set(ruleNames, result);
+			Recognizer._ruleIndexMapCache.set(ruleNames, result);
 		}
 
 		return result;

--- a/src/TokenStreamRewriter.ts
+++ b/src/TokenStreamRewriter.ts
@@ -94,26 +94,26 @@ export class TokenStreamRewriter {
 	static readonly MIN_TOKEN_INDEX: number =  0;
 
 	/** Our source stream */
-	protected tokens: TokenStream;
+	protected _tokens: TokenStream;
 
 	/** You may have multiple, named streams of rewrite operations.
 	 *  I'm calling these things "programs."
 	 *  Maps String (name) &rarr; rewrite (List)
 	 */
-	protected programs: Map<string, RewriteOperation[]>;
+	protected _programs: Map<string, RewriteOperation[]>;
 
 	/** Map String (program name) &rarr; Integer index */
-	protected lastRewriteTokenIndexes: Map<string, number>;
+	protected _lastRewriteTokenIndexes: Map<string, number>;
 
 	 constructor(tokens: TokenStream)  {
-		this.tokens = tokens;
-		this.programs = new Map<string, RewriteOperation[]>();
-		this.programs.set(TokenStreamRewriter.DEFAULT_PROGRAM_NAME, []);
-		this.lastRewriteTokenIndexes = new Map<string, number>();
+		this._tokens = tokens;
+		this._programs = new Map<string, RewriteOperation[]>();
+		this._programs.set(TokenStreamRewriter.DEFAULT_PROGRAM_NAME, []);
+		this._lastRewriteTokenIndexes = new Map<string, number>();
 	}
 
 	getTokenStream(): TokenStream {
-		return this.tokens;
+		return this._tokens;
 	}
 
 	rollback(instructionIndex: number): void;
@@ -123,9 +123,9 @@ export class TokenStreamRewriter {
 	 */
 	rollback(instructionIndex: number, programName: string): void;
 	rollback(instructionIndex: number, programName: string = TokenStreamRewriter.DEFAULT_PROGRAM_NAME): void {
-		let is: RewriteOperation[] | undefined =  this.programs.get(programName);
+		let is: RewriteOperation[] | undefined =  this._programs.get(programName);
 		if ( is!=null ) {
-			this.programs.set(programName, is.slice(TokenStreamRewriter.MIN_TOKEN_INDEX,instructionIndex));
+			this._programs.set(programName, is.slice(TokenStreamRewriter.MIN_TOKEN_INDEX,instructionIndex));
 		}
 	}
 
@@ -150,8 +150,8 @@ export class TokenStreamRewriter {
 		}
 
 		// to insert after, just insert before next index (even if past end)
-		let op = new InsertAfterOp(this.tokens, index, text);
-		let rewrites: RewriteOperation[] = this.getProgram(programName);
+		let op = new InsertAfterOp(this._tokens, index, text);
+		let rewrites: RewriteOperation[] = this._getProgram(programName);
 		op.instructionIndex = rewrites.length;
 		rewrites.push(op);
 	}
@@ -168,8 +168,8 @@ export class TokenStreamRewriter {
 			index = tokenOrIndex.tokenIndex;
 		}
 
-		let op: RewriteOperation = new InsertBeforeOp(this.tokens, index, text);
-		let rewrites: RewriteOperation[] = this.getProgram(programName);
+		let op: RewriteOperation = new InsertBeforeOp(this._tokens, index, text);
+		let rewrites: RewriteOperation[] = this._getProgram(programName);
 		op.instructionIndex = rewrites.length;
 		rewrites.push(op);
 	}
@@ -201,12 +201,12 @@ export class TokenStreamRewriter {
 			to = to.tokenIndex;
 		}
 
-		if ( from > to || from<0 || to<0 || to >= this.tokens.size ) {
-			throw new RangeError(`replace: range invalid: ${from}..${to}(size=${this.tokens.size})`);
+		if ( from > to || from<0 || to<0 || to >= this._tokens.size ) {
+			throw new RangeError(`replace: range invalid: ${from}..${to}(size=${this._tokens.size})`);
 		}
 
-		let op: RewriteOperation =  new ReplaceOp(this.tokens, from, to, text);
-		let rewrites: RewriteOperation[] = this.getProgram(programName);
+		let op: RewriteOperation =  new ReplaceOp(this._tokens, from, to, text);
+		let rewrites: RewriteOperation[] = this._getProgram(programName);
 		op.instructionIndex = rewrites.length;
 		rewrites.push(op);
 	}
@@ -235,12 +235,12 @@ export class TokenStreamRewriter {
 		}
 	}
 
-	protected getLastRewriteTokenIndex(): number;
+	protected _getLastRewriteTokenIndex(): number;
 
-	protected getLastRewriteTokenIndex(programName: string): number;
+	protected _getLastRewriteTokenIndex(programName: string): number;
 
-	protected getLastRewriteTokenIndex(programName: string = TokenStreamRewriter.DEFAULT_PROGRAM_NAME): number {
-		let I: number | undefined = this.lastRewriteTokenIndexes.get(programName);
+	protected _getLastRewriteTokenIndex(programName: string = TokenStreamRewriter.DEFAULT_PROGRAM_NAME): number {
+		let I: number | undefined = this._lastRewriteTokenIndexes.get(programName);
 		if ( I==null ) {
 			return -1;
 		}
@@ -248,12 +248,12 @@ export class TokenStreamRewriter {
 		return I;
 	}
 
-	protected setLastRewriteTokenIndex(programName: string, i: number): void {
-		this.lastRewriteTokenIndexes.set(programName, i);
+	protected _setLastRewriteTokenIndex(programName: string, i: number): void {
+		this._lastRewriteTokenIndexes.set(programName, i);
 	}
 
-	protected getProgram(name: string): RewriteOperation[] {
-		let is: RewriteOperation[] | undefined = this.programs.get(name);
+	protected _getProgram(name: string): RewriteOperation[] {
+		let is: RewriteOperation[] | undefined = this._programs.get(name);
 		if ( is==null ) {
 			is = this._initializeProgram(name);
 		}
@@ -263,7 +263,7 @@ export class TokenStreamRewriter {
 
 	private _initializeProgram(name: string): RewriteOperation[] {
 		let is: RewriteOperation[] = [];
-		this.programs.set(name, is);
+		this._programs.set(name, is);
 		return is;
 	}
 
@@ -297,36 +297,36 @@ export class TokenStreamRewriter {
 		if (intervalOrProgram instanceof Interval) {
 			interval = intervalOrProgram;
 		} else {
-			interval = Interval.of(0, this.tokens.size - 1);
+			interval = Interval.of(0, this._tokens.size - 1);
 		}
 
 		if (typeof intervalOrProgram === 'string') {
 			programName = intervalOrProgram;
 		}
 
-		let rewrites: RewriteOperation[] | undefined = this.programs.get(programName);
+		let rewrites: RewriteOperation[] | undefined = this._programs.get(programName);
 		let start: number =  interval.a;
 		let stop: number =  interval.b;
 
 		// ensure start/end are in range
-		if ( stop > this.tokens.size-1 ) stop = this.tokens.size-1;
+		if ( stop > this._tokens.size-1 ) stop = this._tokens.size-1;
 		if ( start<0 ) start = 0;
 
 		if ( rewrites==null || rewrites.length === 0 ) {
-			return this.tokens.getText(interval); // no instructions to execute
+			return this._tokens.getText(interval); // no instructions to execute
 		}
 
 		let buf: string[] = [];
 
 		// First, optimize instruction stream
-		let indexToOp: Map<number, RewriteOperation> = this.reduceToSingleOperationPerIndex(rewrites);
+		let indexToOp: Map<number, RewriteOperation> = this._reduceToSingleOperationPerIndex(rewrites);
 
 		// Walk buffer, executing instructions and emitting tokens
 		let i: number =  start;
-		while ( i <= stop && i < this.tokens.size ) {
+		while ( i <= stop && i < this._tokens.size ) {
 			let op: RewriteOperation | undefined =  indexToOp.get(i);
 			indexToOp.delete(i); // remove so any left have index size-1
-			let t: Token = this.tokens.get(i);
+			let t: Token = this._tokens.get(i);
 			if ( op==null ) {
 				// no operation at that index, just dump token
 				if ( t.type!==Token.EOF ) buf.push(String(t.text));
@@ -340,11 +340,11 @@ export class TokenStreamRewriter {
 		// include stuff after end if it's last index in buffer
 		// So, if they did an insertAfter(lastValidIndex, "foo"), include
 		// foo if end==lastValidIndex.
-		if ( stop===this.tokens.size-1 ) {
+		if ( stop===this._tokens.size-1 ) {
 			// Scan any remaining operations after last token
 			// should be included (they will be inserts).
 			for (let op of indexToOp.values()) {
-				if ( op.index >= this.tokens.size-1 ) buf += op.text;
+				if ( op.index >= this._tokens.size-1 ) buf += op.text;
 			}
 		}
 
@@ -400,7 +400,7 @@ export class TokenStreamRewriter {
 	 *
 	 *  Return a map from token index to operation.
 	 */
-	protected reduceToSingleOperationPerIndex(rewrites: (RewriteOperation | undefined)[]): Map<number, RewriteOperation> {
+	protected _reduceToSingleOperationPerIndex(rewrites: (RewriteOperation | undefined)[]): Map<number, RewriteOperation> {
 		// console.log(`rewrites=[${Utils.join(rewrites, ", ")}]`);
 
 		// WALK REPLACES
@@ -410,7 +410,7 @@ export class TokenStreamRewriter {
 			if ( !(op instanceof ReplaceOp) ) continue;
 			let rop: ReplaceOp = op;
 			// Wipe prior inserts within range
-			let inserts: InsertBeforeOp[] = this.getKindOfOps(rewrites, InsertBeforeOp, i);
+			let inserts: InsertBeforeOp[] = this._getKindOfOps(rewrites, InsertBeforeOp, i);
 			for (let iop of inserts) {
 				if ( iop.index == rop.index ) {
 					// E.g., insert before 2, delete 2..2; update replace
@@ -424,7 +424,7 @@ export class TokenStreamRewriter {
 				}
 			}
 			// Drop any prior replaces contained within
-			let prevReplaces: ReplaceOp[] = this.getKindOfOps(rewrites, ReplaceOp, i);
+			let prevReplaces: ReplaceOp[] = this._getKindOfOps(rewrites, ReplaceOp, i);
 			for (let prevRop of prevReplaces) {
 				if ( prevRop.index>=rop.index && prevRop.lastIndex <= rop.lastIndex ) {
 					// delete replace as it's a no-op.
@@ -456,27 +456,27 @@ export class TokenStreamRewriter {
 			if ( !(op instanceof InsertBeforeOp) ) continue;
 			let iop: InsertBeforeOp =  op;
 			// combine current insert with prior if any at same index
-			let prevInserts: InsertBeforeOp[] = this.getKindOfOps(rewrites, InsertBeforeOp, i);
+			let prevInserts: InsertBeforeOp[] = this._getKindOfOps(rewrites, InsertBeforeOp, i);
 			for (let prevIop of prevInserts) {
 				if ( prevIop.index === iop.index ) {
 					if (prevIop instanceof InsertAfterOp) {
-						iop.text = this.catOpText(prevIop.text, iop.text);
+						iop.text = this._catOpText(prevIop.text, iop.text);
 						rewrites[prevIop.instructionIndex] = undefined;
 					}
 					else if (prevIop instanceof InsertBeforeOp) { // combine objects
 						// convert to strings...we're in process of toString'ing
 						// whole token buffer so no lazy eval issue with any templates
-						iop.text = this.catOpText(iop.text,prevIop.text);
+						iop.text = this._catOpText(iop.text,prevIop.text);
 						// delete redundant prior insert
 						rewrites[prevIop.instructionIndex] = undefined;
 					}
 				}
 			}
 			// look for replaces where iop.index is in range; error
-			let prevReplaces: ReplaceOp[] = this.getKindOfOps(rewrites, ReplaceOp, i);
+			let prevReplaces: ReplaceOp[] = this._getKindOfOps(rewrites, ReplaceOp, i);
 			for (let rop of prevReplaces) {
 				if ( iop.index == rop.index ) {
-					rop.text = this.catOpText(iop.text,rop.text);
+					rop.text = this._catOpText(iop.text,rop.text);
 					rewrites[i] = undefined;	// delete current insert
 					continue;
 				}
@@ -499,7 +499,7 @@ export class TokenStreamRewriter {
 		return m;
 	}
 
-	protected catOpText(a: any, b: any): string {
+	protected _catOpText(a: any, b: any): string {
 		let x: string =  "";
 		let y: string =  "";
 		if ( a!=null ) x = a.toString();
@@ -508,7 +508,7 @@ export class TokenStreamRewriter {
 	}
 
 	/** Get all operations before an index of a particular kind */
-	protected getKindOfOps<T extends RewriteOperation>(rewrites: (RewriteOperation | undefined)[], kind: {new(...args: any[]): T}, before: number): T[] {
+	protected _getKindOfOps<T extends RewriteOperation>(rewrites: (RewriteOperation | undefined)[], kind: {new(...args: any[]): T}, before: number): T[] {
 		let ops: T[] = [];
 		for (let i=0; i<before && i<rewrites.length; i++) {
 			let op: RewriteOperation | undefined =  rewrites[i];
@@ -524,7 +524,7 @@ export class TokenStreamRewriter {
 // Define the rewrite operation hierarchy
 
 export class RewriteOperation {
-	protected tokens: TokenStream;
+	protected _tokens: TokenStream;
 	/** What index into rewrites List are we? */
 	public instructionIndex: number;
 	/** Token buffer index. */
@@ -534,7 +534,7 @@ export class RewriteOperation {
 	constructor(tokens: TokenStream, index: number);
 	constructor(tokens: TokenStream, index: number, text: any);
 	constructor(tokens: TokenStream, index: number, text?: any) {
-		this.tokens = tokens;
+		this._tokens = tokens;
 		this.index = index;
 		this.text = text;
 	}
@@ -551,7 +551,7 @@ export class RewriteOperation {
 		let opName: string = this.constructor.name;
 		let $index = opName.indexOf('$');
 		opName = opName.substring($index+1, opName.length);
-		return "<"+opName+"@"+this.tokens.get(this.index)+
+		return "<"+opName+"@"+this._tokens.get(this.index)+
 				":\""+this.text+"\">";
 	}
 }
@@ -564,8 +564,8 @@ class InsertBeforeOp extends RewriteOperation {
 	@Override
 	execute(buf: string[]): number {
 		buf.push(this.text);
-		if ( this.tokens.get(this.index).type !== Token.EOF ) {
-			buf.push(String(this.tokens.get(this.index).text));
+		if ( this._tokens.get(this.index).type !== Token.EOF ) {
+			buf.push(String(this._tokens.get(this.index).text));
 		}
 		return this.index+1;
 	}
@@ -602,10 +602,10 @@ class ReplaceOp extends RewriteOperation {
 	@Override
 	toString(): string {
 		if ( this.text==null ) {
-			return "<DeleteOp@"+this.tokens.get(this.index)+
-					".."+this.tokens.get(this.lastIndex)+">";
+			return "<DeleteOp@"+this._tokens.get(this.index)+
+					".."+this._tokens.get(this.lastIndex)+">";
 		}
-		return "<ReplaceOp@"+this.tokens.get(this.index)+
-				".."+this.tokens.get(this.lastIndex)+":\""+this.text+"\">";
+		return "<ReplaceOp@"+this._tokens.get(this.index)+
+				".."+this._tokens.get(this.lastIndex)+":\""+this.text+"\">";
 	}
 }

--- a/src/TokenStreamRewriter.ts
+++ b/src/TokenStreamRewriter.ts
@@ -255,13 +255,13 @@ export class TokenStreamRewriter {
 	protected getProgram(name: string): RewriteOperation[] {
 		let is: RewriteOperation[] | undefined = this.programs.get(name);
 		if ( is==null ) {
-			is = this.initializeProgram(name);
+			is = this._initializeProgram(name);
 		}
 
 		return is;
 	}
 
-	private initializeProgram(name: string): RewriteOperation[] {
+	private _initializeProgram(name: string): RewriteOperation[] {
 		let is: RewriteOperation[] = [];
 		this.programs.set(name, is);
 		return is;

--- a/src/VocabularyImpl.ts
+++ b/src/VocabularyImpl.ts
@@ -28,11 +28,11 @@ export class VocabularyImpl implements Vocabulary {
 	static readonly EMPTY_VOCABULARY: VocabularyImpl = new VocabularyImpl([], [], []);
 
 	@NotNull
-	private readonly literalNames: (string | undefined)[];
+	private readonly _literalNames: (string | undefined)[];
 	@NotNull
-	private readonly symbolicNames: (string | undefined)[];
+	private readonly _symbolicNames: (string | undefined)[];
 	@NotNull
-	private readonly displayNames: (string | undefined)[];
+	private readonly _displayNames: (string | undefined)[];
 
 	private _maxTokenType: number;
 
@@ -54,13 +54,13 @@ export class VocabularyImpl implements Vocabulary {
 	 * @see #getDisplayName(int)
 	 */
 	constructor(literalNames: (string | undefined)[], symbolicNames: (string | undefined)[], displayNames: (string | undefined)[]) {
-		this.literalNames = literalNames;
-		this.symbolicNames = symbolicNames;
-		this.displayNames = displayNames;
+		this._literalNames = literalNames;
+		this._symbolicNames = symbolicNames;
+		this._displayNames = displayNames;
 		// See note here on -1 part: https://github.com/antlr/antlr4/pull/1146
 		this._maxTokenType =
-			Math.max(this.displayNames.length,
-				Math.max(this.literalNames.length, this.symbolicNames.length)) - 1;
+			Math.max(this._displayNames.length,
+				Math.max(this._literalNames.length, this._symbolicNames.length)) - 1;
 	}
 
 	@Override
@@ -70,8 +70,8 @@ export class VocabularyImpl implements Vocabulary {
 
 	@Override
 	getLiteralName(tokenType: number): string | undefined {
-		if (tokenType >= 0 && tokenType < this.literalNames.length) {
-			return this.literalNames[tokenType];
+		if (tokenType >= 0 && tokenType < this._literalNames.length) {
+			return this._literalNames[tokenType];
 		}
 
 		return undefined;
@@ -79,8 +79,8 @@ export class VocabularyImpl implements Vocabulary {
 
 	@Override
 	getSymbolicName(tokenType: number): string | undefined {
-		if (tokenType >= 0 && tokenType < this.symbolicNames.length) {
-			return this.symbolicNames[tokenType];
+		if (tokenType >= 0 && tokenType < this._symbolicNames.length) {
+			return this._symbolicNames[tokenType];
 		}
 
 		if (tokenType === Token.EOF) {
@@ -93,8 +93,8 @@ export class VocabularyImpl implements Vocabulary {
 	@Override
 	@NotNull
 	getDisplayName(tokenType: number): string {
-		if (tokenType >= 0 && tokenType < this.displayNames.length) {
-			let displayName = this.displayNames[tokenType];
+		if (tokenType >= 0 && tokenType < this._displayNames.length) {
+			let displayName = this._displayNames[tokenType];
 			if (displayName) {
 				return displayName;
 			}

--- a/src/atn/ATN.ts
+++ b/src/atn/ATN.ts
@@ -80,7 +80,7 @@ export class ATN {
 	@NotNull
 	modeToStartState: TokensStartState[] = [];
 
-	private contextCache: Array2DHashMap<PredictionContext, PredictionContext> =
+	private _contextCache: Array2DHashMap<PredictionContext, PredictionContext> =
 		new Array2DHashMap<PredictionContext, PredictionContext>(ObjectEqualityComparator.INSTANCE);
 
 	@NotNull
@@ -107,16 +107,16 @@ export class ATN {
 			this.modeToDFA[i] = new DFA(this.modeToStartState[i]);
 		}
 
-		this.contextCache.clear();
+		this._contextCache.clear();
 		this.LL1Table.clear();
 	}
 
 	get contextCacheSize(): number {
-		return this.contextCache.size;
+		return this._contextCache.size;
 	}
 
 	getCachedContext(context: PredictionContext): PredictionContext {
-		return PredictionContext.getCachedContext(context, this.contextCache, new PredictionContext.IdentityHashMap());
+		return PredictionContext.getCachedContext(context, this._contextCache, new PredictionContext.IdentityHashMap());
 	}
 
 	getDecisionToDFA(): DFA[] {

--- a/src/atn/ATNConfigSet.ts
+++ b/src/atn/ATNConfigSet.ts
@@ -226,9 +226,9 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 
 		if (this.mergedConfigs && this.unmerged) {
 			let config: ATNConfig = o;
-			let configKey = this.getKey(config);
+			let configKey = this._getKey(config);
 			let mergedConfig = this.mergedConfigs.get(configKey);
-			if (mergedConfig != null && this.canMerge(config, configKey, mergedConfig)) {
+			if (mergedConfig != null && this._canMerge(config, configKey, mergedConfig)) {
 				return mergedConfig.contains(config);
 			}
 
@@ -272,7 +272,7 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 	add(e: ATNConfig): boolean;
 	add(e: ATNConfig, contextCache: PredictionContextCache | undefined): boolean;
 	add(e: ATNConfig, contextCache?: PredictionContextCache): boolean {
-		this.ensureWritable();
+		this._ensureWritable();
 		if (!this.mergedConfigs || !this.unmerged) {
 			throw new Error("Covered by ensureWritable but duplicated here for strict null check limitation");
 		}
@@ -284,10 +284,10 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 		}
 
 		let addKey: boolean;
-		let key = this.getKey(e);
+		let key = this._getKey(e);
 		let mergedConfig = this.mergedConfigs.get(key);
 		addKey = (mergedConfig == null);
-		if (mergedConfig != null && this.canMerge(e, key, mergedConfig)) {
+		if (mergedConfig != null && this._canMerge(e, key, mergedConfig)) {
 			mergedConfig.outerContextDepth = Math.max(mergedConfig.outerContextDepth, e.outerContextDepth);
 			if (e.isPrecedenceFilterSuppressed) {
 				mergedConfig.isPrecedenceFilterSuppressed = true;
@@ -305,7 +305,7 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 
 		for (let i = 0; i < this.unmerged.length; i++) {
 			let unmergedConfig: ATNConfig = this.unmerged[i];
-			if (this.canMerge(e, key, unmergedConfig)) {
+			if (this._canMerge(e, key, unmergedConfig)) {
 				unmergedConfig.outerContextDepth = Math.max(unmergedConfig.outerContextDepth, e.outerContextDepth);
 				if (e.isPrecedenceFilterSuppressed) {
 					unmergedConfig.isPrecedenceFilterSuppressed = true;
@@ -357,7 +357,7 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 		assert(!this.outermostConfigSet || !this._dipsIntoOuterContext);
 	}
 
-	protected canMerge(left: ATNConfig, leftKey: { state: number, alt: number }, right: ATNConfig): boolean {
+	protected _canMerge(left: ATNConfig, leftKey: { state: number, alt: number }, right: ATNConfig): boolean {
 		if (left.state.stateNumber != right.state.stateNumber) {
 			return false;
 		}
@@ -369,7 +369,7 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 		return left.semanticContext.equals(right.semanticContext);
 	}
 
-	protected getKey(e: ATNConfig): { state: number, alt: number } {
+	protected _getKey(e: ATNConfig): { state: number, alt: number } {
 		return { state: e.state.stateNumber, alt: e.alt };
 	}
 
@@ -391,7 +391,7 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 	addAll(c: Collection<ATNConfig>): boolean;
 	addAll(c: Collection<ATNConfig>, contextCache: PredictionContextCache): boolean;
 	addAll(c: Collection<ATNConfig>, contextCache?: PredictionContextCache): boolean {
-		this.ensureWritable();
+		this._ensureWritable();
 
 		let changed: boolean = false;
 		for (let group of asIterable(c)) {
@@ -405,19 +405,19 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 
 	@Override
 	retainAll(c: Collection<any>): boolean {
-		this.ensureWritable();
+		this._ensureWritable();
 		throw new Error("Not supported yet.");
 	}
 
 	@Override
 	removeAll(c: Collection<any>): boolean {
-		this.ensureWritable();
+		this._ensureWritable();
 		throw new Error("Not supported yet.");
 	}
 
 	@Override
 	clear(): void {
-		this.ensureWritable();
+		this._ensureWritable();
 		if (!this.mergedConfigs || !this.unmerged) {
 			throw new Error("Covered by ensureWritable but duplicated here for strict null check limitation");
 		}
@@ -515,7 +515,7 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 	}
 
 	set hasSemanticContext(value: boolean) {
-		this.ensureWritable();
+		this._ensureWritable();
 		this._hasSemanticContext = value;
 	}
 
@@ -524,7 +524,7 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 	}
 
 	set conflictInfo(conflictInfo: ConflictInfo | undefined) {
-		this.ensureWritable();
+		this._ensureWritable();
 		this._conflictInfo = conflictInfo;
 	}
 
@@ -562,7 +562,7 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 	remove(o: any): boolean;
 	remove(index: number): void;
 	remove(indexOrItem: number | any): boolean | void {
-		this.ensureWritable();
+		this._ensureWritable();
 		if (!this.mergedConfigs || !this.unmerged) {
 			throw new Error("Covered by ensureWritable but duplicated here for strict null check limitation");
 		}
@@ -574,7 +574,7 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 		let index = indexOrItem;
 		let config: ATNConfig = this.configs[index];
 		this.configs.splice(index, 1);
-		let key = this.getKey(config);
+		let key = this._getKey(config);
 		if (this.mergedConfigs.get(key) === config) {
 			this.mergedConfigs.remove(key);
 		} else {
@@ -587,7 +587,7 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 		}
 	}
 
-	protected ensureWritable(): void {
+	protected _ensureWritable(): void {
 		if (this.isReadOnly) {
 			throw new Error("This ATNConfigSet is read only.");
 		}

--- a/src/atn/ATNDeserializationOptions.ts
+++ b/src/atn/ATNDeserializationOptions.ts
@@ -54,7 +54,7 @@ export class ATNDeserializationOptions {
 	}
 
 	set isVerifyATN(verifyATN: boolean) {
-		this.throwIfReadOnly();
+		this._throwIfReadOnly();
 		this._verifyATN = verifyATN;
 	}
 
@@ -63,7 +63,7 @@ export class ATNDeserializationOptions {
 	}
 
 	set isGenerateRuleBypassTransitions(generateRuleBypassTransitions: boolean) {
-		this.throwIfReadOnly();
+		this._throwIfReadOnly();
 		this._generateRuleBypassTransitions = generateRuleBypassTransitions;
 	}
 
@@ -72,11 +72,11 @@ export class ATNDeserializationOptions {
 	}
 
 	set isOptimize(optimize: boolean) {
-		this.throwIfReadOnly();
+		this._throwIfReadOnly();
 		this._optimize = optimize;
 	}
 
-	protected throwIfReadOnly(): void {
+	protected _throwIfReadOnly(): void {
 		if (this.isReadOnly) {
 			throw new Error("The object is read only.");
 		}

--- a/src/atn/ATNDeserializationOptions.ts
+++ b/src/atn/ATNDeserializationOptions.ts
@@ -78,7 +78,7 @@ export class ATNDeserializationOptions {
 
 	protected throwIfReadOnly(): void {
 		if (this.isReadOnly) {
-			throw "The object is read only.";
+			throw new Error("The object is read only.");
 		}
 	}
 }

--- a/src/atn/ATNDeserializationOptions.ts
+++ b/src/atn/ATNDeserializationOptions.ts
@@ -14,20 +14,20 @@ import { NotNull } from '../Decorators';
 export class ATNDeserializationOptions {
 	private static _defaultOptions?: ATNDeserializationOptions;
 
-	private readOnly: boolean = false;
-	private verifyATN: boolean;
-	private generateRuleBypassTransitions: boolean;
-	private optimize: boolean;
+	private _readOnly: boolean = false;
+	private _verifyATN: boolean;
+	private _generateRuleBypassTransitions: boolean;
+	private _optimize: boolean;
 
 	constructor(options?: ATNDeserializationOptions) {
 		if (options) {
-			this.verifyATN = options.verifyATN;
-			this.generateRuleBypassTransitions = options.generateRuleBypassTransitions;
-			this.optimize = options.optimize;
+			this._verifyATN = options._verifyATN;
+			this._generateRuleBypassTransitions = options._generateRuleBypassTransitions;
+			this._optimize = options._optimize;
 		} else {
-			this.verifyATN = true;
-			this.generateRuleBypassTransitions = false;
-			this.optimize = true;
+			this._verifyATN = true;
+			this._generateRuleBypassTransitions = false;
+			this._optimize = true;
 		}
 	}
 
@@ -42,38 +42,38 @@ export class ATNDeserializationOptions {
 	}
 
 	get isReadOnly(): boolean {
-		return this.readOnly;
+		return this._readOnly;
 	}
 
 	makeReadOnly(): void {
-		this.readOnly = true;
+		this._readOnly = true;
 	}
 
 	get isVerifyATN(): boolean {
-		return this.verifyATN;
+		return this._verifyATN;
 	}
 
 	set isVerifyATN(verifyATN: boolean) {
 		this.throwIfReadOnly();
-		this.verifyATN = verifyATN;
+		this._verifyATN = verifyATN;
 	}
 
 	get isGenerateRuleBypassTransitions(): boolean {
-		return this.generateRuleBypassTransitions;
+		return this._generateRuleBypassTransitions;
 	}
 
 	set isGenerateRuleBypassTransitions(generateRuleBypassTransitions: boolean) {
 		this.throwIfReadOnly();
-		this.generateRuleBypassTransitions = generateRuleBypassTransitions;
+		this._generateRuleBypassTransitions = generateRuleBypassTransitions;
 	}
 
 	get isOptimize(): boolean {
-		return this.optimize;
+		return this._optimize;
 	}
 
 	set isOptimize(optimize: boolean) {
 		this.throwIfReadOnly();
-		this.optimize = optimize;
+		this._optimize = optimize;
 	}
 
 	protected throwIfReadOnly(): void {

--- a/src/atn/ATNDeserializer.ts
+++ b/src/atn/ATNDeserializer.ts
@@ -121,7 +121,7 @@ export class ATNDeserializer {
 	 * serialized ATN at or after the feature identified by {@code feature} was
 	 * introduced; otherwise, {@code false}.
 	 */
-	protected isFeatureSupported(feature: UUID, actualUuid: UUID): boolean {
+	protected _isFeatureSupported(feature: UUID, actualUuid: UUID): boolean {
 		let featureIndex: number = ATNDeserializer._SUPPORTED_UUIDS.findIndex(e => e.equals(feature));
 		if (featureIndex < 0) {
 			return false;
@@ -147,23 +147,23 @@ export class ATNDeserializer {
 		}
 
 		let p: number = 0;
-		let version: number = ATNDeserializer.toInt(data[p++]);
+		let version: number = ATNDeserializer._toInt(data[p++]);
 		if (version != ATNDeserializer.SERIALIZED_VERSION) {
 			let reason = `Could not deserialize ATN with version ${version} (expected ${ATNDeserializer.SERIALIZED_VERSION}).`;
 			throw new Error(reason);
 		}
 
-		let uuid: UUID = ATNDeserializer.toUUID(data, p);
+		let uuid: UUID = ATNDeserializer._toUUID(data, p);
 		p += 8;
 		if (ATNDeserializer._SUPPORTED_UUIDS.findIndex(e => e.equals(uuid)) < 0) {
 			let reason = `Could not deserialize ATN with UUID ${uuid} (expected ${ATNDeserializer._SERIALIZED_UUID} or a legacy UUID).`;
 			throw new Error(reason);
 		}
 
-		let supportsLexerActions: boolean = this.isFeatureSupported(ATNDeserializer._ADDED_LEXER_ACTIONS, uuid);
+		let supportsLexerActions: boolean = this._isFeatureSupported(ATNDeserializer._ADDED_LEXER_ACTIONS, uuid);
 
-		let grammarType: ATNType = ATNDeserializer.toInt(data[p++]);
-		let maxTokenType: number = ATNDeserializer.toInt(data[p++]);
+		let grammarType: ATNType = ATNDeserializer._toInt(data[p++]);
+		let maxTokenType: number = ATNDeserializer._toInt(data[p++]);
 		let atn: ATN = new ATN(grammarType, maxTokenType);
 
 		//
@@ -171,27 +171,27 @@ export class ATNDeserializer {
 		//
 		let loopBackStateNumbers: [LoopEndState, number][] = [];
 		let endStateNumbers: [BlockStartState, number][] = [];
-		let nstates: number = ATNDeserializer.toInt(data[p++]);
+		let nstates: number = ATNDeserializer._toInt(data[p++]);
 		for (let i = 0; i < nstates; i++) {
-			let stype: ATNStateType = ATNDeserializer.toInt(data[p++]);
+			let stype: ATNStateType = ATNDeserializer._toInt(data[p++]);
 			// ignore bad type of states
 			if (stype === ATNStateType.INVALID_TYPE) {
 				atn.addState(new InvalidState());
 				continue;
 			}
 
-			let ruleIndex: number = ATNDeserializer.toInt(data[p++]);
+			let ruleIndex: number = ATNDeserializer._toInt(data[p++]);
 			if (ruleIndex === 0xFFFF) {
 				ruleIndex = -1;
 			}
 
-			let s: ATNState = this.stateFactory(stype, ruleIndex);
+			let s: ATNState = this._stateFactory(stype, ruleIndex);
 			if (stype === ATNStateType.LOOP_END) { // special case
-				let loopBackStateNumber: number = ATNDeserializer.toInt(data[p++]);
+				let loopBackStateNumber: number = ATNDeserializer._toInt(data[p++]);
 				loopBackStateNumbers.push([<LoopEndState>s, loopBackStateNumber]);
 			}
 			else if (s instanceof BlockStartState) {
-				let endStateNumber: number = ATNDeserializer.toInt(data[p++]);
+				let endStateNumber: number = ATNDeserializer._toInt(data[p++]);
 				endStateNumbers.push([s, endStateNumber]);
 			}
 			atn.addState(s);
@@ -206,50 +206,50 @@ export class ATNDeserializer {
 			pair[0].endState = <BlockEndState>atn.states[pair[1]];
 		}
 
-		let numNonGreedyStates: number = ATNDeserializer.toInt(data[p++]);
+		let numNonGreedyStates: number = ATNDeserializer._toInt(data[p++]);
 		for (let i = 0; i < numNonGreedyStates; i++) {
-			let stateNumber: number = ATNDeserializer.toInt(data[p++]);
+			let stateNumber: number = ATNDeserializer._toInt(data[p++]);
 			(<DecisionState>atn.states[stateNumber]).nonGreedy = true;
 		}
 
-		let numSllDecisions: number = ATNDeserializer.toInt(data[p++]);
+		let numSllDecisions: number = ATNDeserializer._toInt(data[p++]);
 		for (let i = 0; i < numSllDecisions; i++) {
-			let stateNumber: number = ATNDeserializer.toInt(data[p++]);
+			let stateNumber: number = ATNDeserializer._toInt(data[p++]);
 			(<DecisionState>atn.states[stateNumber]).sll = true;
 		}
 
-		let numPrecedenceStates: number = ATNDeserializer.toInt(data[p++]);
+		let numPrecedenceStates: number = ATNDeserializer._toInt(data[p++]);
 		for (let i = 0; i < numPrecedenceStates; i++) {
-			let stateNumber: number = ATNDeserializer.toInt(data[p++]);
+			let stateNumber: number = ATNDeserializer._toInt(data[p++]);
 			(<RuleStartState>atn.states[stateNumber]).isPrecedenceRule = true;
 		}
 
 		//
 		// RULES
 		//
-		let nrules: number = ATNDeserializer.toInt(data[p++]);
+		let nrules: number = ATNDeserializer._toInt(data[p++]);
 		if (atn.grammarType === ATNType.LEXER) {
 			atn.ruleToTokenType = new Int32Array(nrules);
 		}
 
 		atn.ruleToStartState = new Array<RuleStartState>(nrules);
 		for (let i = 0; i < nrules; i++) {
-			let s: number = ATNDeserializer.toInt(data[p++]);
+			let s: number = ATNDeserializer._toInt(data[p++]);
 			let startState: RuleStartState = <RuleStartState>atn.states[s];
-			startState.leftFactored = ATNDeserializer.toInt(data[p++]) != 0;
+			startState.leftFactored = ATNDeserializer._toInt(data[p++]) != 0;
 			atn.ruleToStartState[i] = startState;
 			if (atn.grammarType === ATNType.LEXER) {
-				let tokenType: number = ATNDeserializer.toInt(data[p++]);
+				let tokenType: number = ATNDeserializer._toInt(data[p++]);
 				if (tokenType === 0xFFFF) {
 					tokenType = Token.EOF;
 				}
 
 				atn.ruleToTokenType[i] = tokenType;
 
-				if (!this.isFeatureSupported(ATNDeserializer._ADDED_LEXER_ACTIONS, uuid)) {
+				if (!this._isFeatureSupported(ATNDeserializer._ADDED_LEXER_ACTIONS, uuid)) {
 					// this piece of unused metadata was serialized prior to the
 					// addition of LexerAction
-					let actionIndexIgnored: number = ATNDeserializer.toInt(data[p++]);
+					let actionIndexIgnored: number = ATNDeserializer._toInt(data[p++]);
 					if (actionIndexIgnored === 0xFFFF) {
 						actionIndexIgnored = -1;
 					}
@@ -270,9 +270,9 @@ export class ATNDeserializer {
 		//
 		// MODES
 		//
-		let nmodes: number = ATNDeserializer.toInt(data[p++]);
+		let nmodes: number = ATNDeserializer._toInt(data[p++]);
 		for (let i = 0; i < nmodes; i++) {
-			let s: number = ATNDeserializer.toInt(data[p++]);
+			let s: number = ATNDeserializer._toInt(data[p++]);
 			atn.modeToStartState.push(<TokensStartState>atn.states[s]);
 		}
 
@@ -285,20 +285,20 @@ export class ATNDeserializer {
 		// SETS
 		//
 		let sets: IntervalSet[] = [];
-		let nsets: number = ATNDeserializer.toInt(data[p++]);
+		let nsets: number = ATNDeserializer._toInt(data[p++]);
 		for (let i = 0; i < nsets; i++) {
-			let nintervals: number = ATNDeserializer.toInt(data[p]);
+			let nintervals: number = ATNDeserializer._toInt(data[p]);
 			p++;
 			let set: IntervalSet = new IntervalSet();
 			sets.push(set);
 
-			let containsEof: boolean = ATNDeserializer.toInt(data[p++]) != 0;
+			let containsEof: boolean = ATNDeserializer._toInt(data[p++]) != 0;
 			if (containsEof) {
 				set.add(-1);
 			}
 
 			for (let j = 0; j < nintervals; j++) {
-				set.add(ATNDeserializer.toInt(data[p]), ATNDeserializer.toInt(data[p + 1]));
+				set.add(ATNDeserializer._toInt(data[p]), ATNDeserializer._toInt(data[p + 1]));
 				p += 2;
 			}
 		}
@@ -306,15 +306,15 @@ export class ATNDeserializer {
 		//
 		// EDGES
 		//
-		let nedges: number = ATNDeserializer.toInt(data[p++]);
+		let nedges: number = ATNDeserializer._toInt(data[p++]);
 		for (let i = 0; i < nedges; i++) {
-			let src: number = ATNDeserializer.toInt(data[p]);
-			let trg: number = ATNDeserializer.toInt(data[p + 1]);
-			let ttype: number = ATNDeserializer.toInt(data[p + 2]);
-			let arg1: number = ATNDeserializer.toInt(data[p + 3]);
-			let arg2: number = ATNDeserializer.toInt(data[p + 4]);
-			let arg3: number = ATNDeserializer.toInt(data[p + 5]);
-			let trans: Transition = this.edgeFactory(atn, ttype, src, trg, arg1, arg2, arg3, sets);
+			let src: number = ATNDeserializer._toInt(data[p]);
+			let trg: number = ATNDeserializer._toInt(data[p + 1]);
+			let ttype: number = ATNDeserializer._toInt(data[p + 2]);
+			let arg1: number = ATNDeserializer._toInt(data[p + 3]);
+			let arg2: number = ATNDeserializer._toInt(data[p + 4]);
+			let arg3: number = ATNDeserializer._toInt(data[p + 5]);
+			let trans: Transition = this._edgeFactory(atn, ttype, src, trg, arg1, arg2, arg3, sets);
 			// console.log(`EDGE ${trans.constructor.name} ${src}->${trg} ${Transition.serializationNames[ttype]} ${arg1},${arg2},${arg3}`);
 			let srcState: ATNState = atn.states[src];
 			srcState.addTransition(trans);
@@ -405,9 +405,9 @@ export class ATNDeserializer {
 		//
 		// DECISIONS
 		//
-		let ndecisions: number = ATNDeserializer.toInt(data[p++]);
+		let ndecisions: number = ATNDeserializer._toInt(data[p++]);
 		for (let i = 1; i <= ndecisions; i++) {
-			let s: number = ATNDeserializer.toInt(data[p++]);
+			let s: number = ATNDeserializer._toInt(data[p++]);
 			let decState: DecisionState = <DecisionState>atn.states[s];
 			atn.decisionToState.push(decState);
 			decState.decision = i - 1;
@@ -418,20 +418,20 @@ export class ATNDeserializer {
 		//
 		if (atn.grammarType === ATNType.LEXER) {
 			if (supportsLexerActions) {
-				atn.lexerActions = new Array<LexerAction>(ATNDeserializer.toInt(data[p++]));
+				atn.lexerActions = new Array<LexerAction>(ATNDeserializer._toInt(data[p++]));
 				for (let i = 0; i < atn.lexerActions.length; i++) {
-					let actionType: LexerActionType = ATNDeserializer.toInt(data[p++]);
-					let data1: number = ATNDeserializer.toInt(data[p++]);
+					let actionType: LexerActionType = ATNDeserializer._toInt(data[p++]);
+					let data1: number = ATNDeserializer._toInt(data[p++]);
 					if (data1 == 0xFFFF) {
 						data1 = -1;
 					}
 
-					let data2: number = ATNDeserializer.toInt(data[p++]);
+					let data2: number = ATNDeserializer._toInt(data[p++]);
 					if (data2 == 0xFFFF) {
 						data2 = -1;
 					}
 
-					let lexerAction: LexerAction = this.lexerActionFactory(actionType, data1, data2);
+					let lexerAction: LexerAction = this._lexerActionFactory(actionType, data1, data2);
 
 					atn.lexerActions[i] = lexerAction;
 				}
@@ -460,7 +460,7 @@ export class ATNDeserializer {
 			}
 		}
 
-		this.markPrecedenceDecisions(atn);
+		this._markPrecedenceDecisions(atn);
 
 		atn.decisionToDFA = new Array<DFA>(ndecisions);
 		for (let i = 0; i < ndecisions; i++) {
@@ -468,7 +468,7 @@ export class ATNDeserializer {
 		}
 
 		if (this._deserializationOptions.isVerifyATN) {
-			this.verifyATN(atn);
+			this._verifyATN(atn);
 		}
 
 		if (this._deserializationOptions.isGenerateRuleBypassTransitions && atn.grammarType === ATNType.PARSER) {
@@ -558,7 +558,7 @@ export class ATNDeserializer {
 
 			if (this._deserializationOptions.isVerifyATN) {
 				// reverify after modification
-				this.verifyATN(atn);
+				this._verifyATN(atn);
 			}
 		}
 
@@ -576,7 +576,7 @@ export class ATNDeserializer {
 
 			if (this._deserializationOptions.isVerifyATN) {
 				// reverify after modification
-				this.verifyATN(atn);
+				this._verifyATN(atn);
 			}
 		}
 
@@ -592,7 +592,7 @@ export class ATNDeserializer {
 	 *
 	 * @param atn The ATN.
 	 */
-	protected markPrecedenceDecisions(@NotNull atn: ATN): void {
+	protected _markPrecedenceDecisions(@NotNull atn: ATN): void {
 		// Map rule index -> precedence decision for that rule
 		let rulePrecedenceDecisions = new Map<number, StarLoopEntryState>();
 
@@ -635,32 +635,32 @@ export class ATNDeserializer {
 		}
 	}
 
-	protected verifyATN(atn: ATN): void {
+	protected _verifyATN(atn: ATN): void {
 		// verify assumptions
 		for (let state of atn.states) {
-			this.checkCondition(state != null, "ATN states should not be null.");
+			this._checkCondition(state != null, "ATN states should not be null.");
 			if (state.stateType === ATNStateType.INVALID_TYPE) {
 				continue;
 			}
 
-			this.checkCondition(state.onlyHasEpsilonTransitions || state.numberOfTransitions <= 1);
+			this._checkCondition(state.onlyHasEpsilonTransitions || state.numberOfTransitions <= 1);
 
 			if (state instanceof PlusBlockStartState) {
-				this.checkCondition(state.loopBackState != null);
+				this._checkCondition(state.loopBackState != null);
 			}
 
 			if (state instanceof StarLoopEntryState) {
 				let starLoopEntryState: StarLoopEntryState = state;
-				this.checkCondition(starLoopEntryState.loopBackState != null);
-				this.checkCondition(starLoopEntryState.numberOfTransitions === 2);
+				this._checkCondition(starLoopEntryState.loopBackState != null);
+				this._checkCondition(starLoopEntryState.numberOfTransitions === 2);
 
 				if (starLoopEntryState.transition(0).target instanceof StarBlockStartState) {
-					this.checkCondition(starLoopEntryState.transition(1).target instanceof LoopEndState);
-					this.checkCondition(!starLoopEntryState.nonGreedy);
+					this._checkCondition(starLoopEntryState.transition(1).target instanceof LoopEndState);
+					this._checkCondition(!starLoopEntryState.nonGreedy);
 				}
 				else if (starLoopEntryState.transition(0).target instanceof LoopEndState) {
-					this.checkCondition(starLoopEntryState.transition(1).target instanceof StarBlockStartState);
-					this.checkCondition(starLoopEntryState.nonGreedy);
+					this._checkCondition(starLoopEntryState.transition(1).target instanceof StarBlockStartState);
+					this._checkCondition(starLoopEntryState.nonGreedy);
 				}
 				else {
 					throw new Error("IllegalStateException");
@@ -668,37 +668,37 @@ export class ATNDeserializer {
 			}
 
 			if (state instanceof StarLoopbackState) {
-				this.checkCondition(state.numberOfTransitions === 1);
-				this.checkCondition(state.transition(0).target instanceof StarLoopEntryState);
+				this._checkCondition(state.numberOfTransitions === 1);
+				this._checkCondition(state.transition(0).target instanceof StarLoopEntryState);
 			}
 
 			if (state instanceof LoopEndState) {
-				this.checkCondition(state.loopBackState != null);
+				this._checkCondition(state.loopBackState != null);
 			}
 
 			if (state instanceof RuleStartState) {
-				this.checkCondition(state.stopState != null);
+				this._checkCondition(state.stopState != null);
 			}
 
 			if (state instanceof BlockStartState) {
-				this.checkCondition(state.endState != null);
+				this._checkCondition(state.endState != null);
 			}
 
 			if (state instanceof BlockEndState) {
-				this.checkCondition(state.startState != null);
+				this._checkCondition(state.startState != null);
 			}
 
 			if (state instanceof DecisionState) {
 				let decisionState: DecisionState = state;
-				this.checkCondition(decisionState.numberOfTransitions <= 1 || decisionState.decision >= 0);
+				this._checkCondition(decisionState.numberOfTransitions <= 1 || decisionState.decision >= 0);
 			}
 			else {
-				this.checkCondition(state.numberOfTransitions <= 1 || state instanceof RuleStopState);
+				this._checkCondition(state.numberOfTransitions <= 1 || state instanceof RuleStopState);
 			}
 		}
 	}
 
-	protected checkCondition(condition: boolean, message?: string): void {
+	protected _checkCondition(condition: boolean, message?: string): void {
 		if (!condition) {
 			throw new Error("IllegalStateException: " + message);
 		}
@@ -1067,24 +1067,24 @@ export class ATNDeserializer {
 		return true;
 	}
 
-	protected static toInt(c: number): number {
+	protected static _toInt(c: number): number {
 		return c;
 	}
 
-	protected static toInt32(data: Uint16Array, offset: number): number {
+	protected static _toInt32(data: Uint16Array, offset: number): number {
 		return (data[offset] | (data[offset + 1] << 16)) >>> 0;
 	}
 
-	protected static toUUID(data: Uint16Array, offset: number): UUID {
-		let leastSigBits: number = ATNDeserializer.toInt32(data, offset);
-		let lessSigBits: number = ATNDeserializer.toInt32(data, offset + 2);
-		let moreSigBits: number = ATNDeserializer.toInt32(data, offset + 4);
-		let mostSigBits: number = ATNDeserializer.toInt32(data, offset + 6);
+	protected static _toUUID(data: Uint16Array, offset: number): UUID {
+		let leastSigBits: number = ATNDeserializer._toInt32(data, offset);
+		let lessSigBits: number = ATNDeserializer._toInt32(data, offset + 2);
+		let moreSigBits: number = ATNDeserializer._toInt32(data, offset + 4);
+		let mostSigBits: number = ATNDeserializer._toInt32(data, offset + 6);
 		return new UUID(mostSigBits, moreSigBits, lessSigBits, leastSigBits);
 	}
 
 	@NotNull
-	protected edgeFactory(@NotNull atn: ATN,
+	protected _edgeFactory(@NotNull atn: ATN,
 		type: TransitionType, src: number, trg: number,
 		arg1: number, arg2: number, arg3: number,
 		sets: IntervalSet[]): Transition {
@@ -1124,7 +1124,7 @@ export class ATNDeserializer {
 		throw new Error("The specified transition type is not valid.");
 	}
 
-	protected stateFactory(type: ATNStateType, ruleIndex: number): ATNState {
+	protected _stateFactory(type: ATNStateType, ruleIndex: number): ATNState {
 		let s: ATNState;
 		switch (type) {
 			case ATNStateType.INVALID_TYPE: return new InvalidState();
@@ -1149,7 +1149,7 @@ export class ATNDeserializer {
 		return s;
 	}
 
-	protected lexerActionFactory(type: LexerActionType, data1: number, data2: number): LexerAction {
+	protected _lexerActionFactory(type: LexerActionType, data1: number, data2: number): LexerAction {
 		switch (type) {
 		case LexerActionType.CHANNEL:
 			return new LexerChannelAction(data1);

--- a/src/atn/ATNDeserializer.ts
+++ b/src/atn/ATNDeserializer.ts
@@ -76,36 +76,36 @@ export class ATNDeserializer {
 	/**
 	 * This is the earliest supported serialized UUID.
 	 */
-	private static readonly BASE_SERIALIZED_UUID: UUID = UUID.fromString("E4178468-DF95-44D0-AD87-F22A5D5FB6D3");
+	private static readonly _BASE_SERIALIZED_UUID: UUID = UUID.fromString("E4178468-DF95-44D0-AD87-F22A5D5FB6D3");
 	/**
 	 * This UUID indicates an extension of {@link #ADDED_PRECEDENCE_TRANSITIONS}
 	 * for the addition of lexer actions encoded as a sequence of
 	 * {@link LexerAction} instances.
 	 */
-	private static readonly ADDED_LEXER_ACTIONS: UUID = UUID.fromString("AB35191A-1603-487E-B75A-479B831EAF6D");
+	private static readonly _ADDED_LEXER_ACTIONS: UUID = UUID.fromString("AB35191A-1603-487E-B75A-479B831EAF6D");
 	/**
 	 * This list contains all of the currently supported UUIDs, ordered by when
 	 * the feature first appeared in this branch.
 	 */
-	private static readonly SUPPORTED_UUIDS: UUID[] = [
-		ATNDeserializer.BASE_SERIALIZED_UUID,
-		ATNDeserializer.ADDED_LEXER_ACTIONS
+	private static readonly _SUPPORTED_UUIDS: UUID[] = [
+		ATNDeserializer._BASE_SERIALIZED_UUID,
+		ATNDeserializer._ADDED_LEXER_ACTIONS
 	];
 
 	/**
 	 * This is the current serialized UUID.
 	 */
-	private static readonly SERIALIZED_UUID: UUID = ATNDeserializer.ADDED_LEXER_ACTIONS;
+	private static readonly _SERIALIZED_UUID: UUID = ATNDeserializer._ADDED_LEXER_ACTIONS;
 
 	@NotNull
-	private readonly deserializationOptions: ATNDeserializationOptions;
+	private readonly _deserializationOptions: ATNDeserializationOptions;
 
 	constructor(deserializationOptions?: ATNDeserializationOptions) {
 		if (deserializationOptions == null) {
 			deserializationOptions = ATNDeserializationOptions.defaultOptions;
 		}
 
-		this.deserializationOptions = deserializationOptions;
+		this._deserializationOptions = deserializationOptions;
 	}
 
 	/**
@@ -122,12 +122,12 @@ export class ATNDeserializer {
 	 * introduced; otherwise, {@code false}.
 	 */
 	protected isFeatureSupported(feature: UUID, actualUuid: UUID): boolean {
-		let featureIndex: number = ATNDeserializer.SUPPORTED_UUIDS.findIndex(e => e.equals(feature));
+		let featureIndex: number = ATNDeserializer._SUPPORTED_UUIDS.findIndex(e => e.equals(feature));
 		if (featureIndex < 0) {
 			return false;
 		}
 
-		return ATNDeserializer.SUPPORTED_UUIDS.findIndex(e => e.equals(actualUuid)) >= featureIndex;
+		return ATNDeserializer._SUPPORTED_UUIDS.findIndex(e => e.equals(actualUuid)) >= featureIndex;
 	}
 
 	deserialize(@NotNull data: Uint16Array): ATN {
@@ -155,12 +155,12 @@ export class ATNDeserializer {
 
 		let uuid: UUID = ATNDeserializer.toUUID(data, p);
 		p += 8;
-		if (ATNDeserializer.SUPPORTED_UUIDS.findIndex(e => e.equals(uuid)) < 0) {
-			let reason = `Could not deserialize ATN with UUID ${uuid} (expected ${ATNDeserializer.SERIALIZED_UUID} or a legacy UUID).`;
+		if (ATNDeserializer._SUPPORTED_UUIDS.findIndex(e => e.equals(uuid)) < 0) {
+			let reason = `Could not deserialize ATN with UUID ${uuid} (expected ${ATNDeserializer._SERIALIZED_UUID} or a legacy UUID).`;
 			throw new Error(reason);
 		}
 
-		let supportsLexerActions: boolean = this.isFeatureSupported(ATNDeserializer.ADDED_LEXER_ACTIONS, uuid);
+		let supportsLexerActions: boolean = this.isFeatureSupported(ATNDeserializer._ADDED_LEXER_ACTIONS, uuid);
 
 		let grammarType: ATNType = ATNDeserializer.toInt(data[p++]);
 		let maxTokenType: number = ATNDeserializer.toInt(data[p++]);
@@ -246,7 +246,7 @@ export class ATNDeserializer {
 
 				atn.ruleToTokenType[i] = tokenType;
 
-				if (!this.isFeatureSupported(ATNDeserializer.ADDED_LEXER_ACTIONS, uuid)) {
+				if (!this.isFeatureSupported(ATNDeserializer._ADDED_LEXER_ACTIONS, uuid)) {
 					// this piece of unused metadata was serialized prior to the
 					// addition of LexerAction
 					let actionIndexIgnored: number = ATNDeserializer.toInt(data[p++]);
@@ -467,11 +467,11 @@ export class ATNDeserializer {
 			atn.decisionToDFA[i] = new DFA(atn.decisionToState[i], i);
 		}
 
-		if (this.deserializationOptions.isVerifyATN) {
+		if (this._deserializationOptions.isVerifyATN) {
 			this.verifyATN(atn);
 		}
 
-		if (this.deserializationOptions.isGenerateRuleBypassTransitions && atn.grammarType === ATNType.PARSER) {
+		if (this._deserializationOptions.isGenerateRuleBypassTransitions && atn.grammarType === ATNType.PARSER) {
 			atn.ruleToTokenType = new Int32Array(atn.ruleToStartState.length);
 			for (let i = 0; i < atn.ruleToStartState.length; i++) {
 				atn.ruleToTokenType[i] = atn.maxTokenType + i + 1;
@@ -556,31 +556,31 @@ export class ATNDeserializer {
 				bypassStart.addTransition(new EpsilonTransition(matchState));
 			}
 
-			if (this.deserializationOptions.isVerifyATN) {
+			if (this._deserializationOptions.isVerifyATN) {
 				// reverify after modification
 				this.verifyATN(atn);
 			}
 		}
 
-		if (this.deserializationOptions.isOptimize) {
+		if (this._deserializationOptions.isOptimize) {
 			while (true) {
 				let optimizationCount: number = 0;
-				optimizationCount += ATNDeserializer.inlineSetRules(atn);
-				optimizationCount += ATNDeserializer.combineChainedEpsilons(atn);
+				optimizationCount += ATNDeserializer._inlineSetRules(atn);
+				optimizationCount += ATNDeserializer._combineChainedEpsilons(atn);
 				let preserveOrder: boolean = atn.grammarType === ATNType.LEXER;
-				optimizationCount += ATNDeserializer.optimizeSets(atn, preserveOrder);
+				optimizationCount += ATNDeserializer._optimizeSets(atn, preserveOrder);
 				if (optimizationCount === 0) {
 					break;
 				}
 			}
 
-			if (this.deserializationOptions.isVerifyATN) {
+			if (this._deserializationOptions.isVerifyATN) {
 				// reverify after modification
 				this.verifyATN(atn);
 			}
 		}
 
-		ATNDeserializer.identifyTailCalls(atn);
+		ATNDeserializer._identifyTailCalls(atn);
 
 		return atn;
 	}
@@ -704,7 +704,7 @@ export class ATNDeserializer {
 		}
 	}
 
-	private static inlineSetRules(atn: ATN): number {
+	private static _inlineSetRules(atn: ATN): number {
 		let inlinedCalls: number = 0;
 
 		let ruleToInlineTransition: Transition[] = new Array<Transition>(atn.ruleToStartState.length);
@@ -826,7 +826,7 @@ export class ATNDeserializer {
 		return inlinedCalls;
 	}
 
-	private static combineChainedEpsilons(atn: ATN): number {
+	private static _combineChainedEpsilons(atn: ATN): number {
 		let removedEdges: number = 0;
 
 		for (let state of atn.states) {
@@ -895,7 +895,7 @@ export class ATNDeserializer {
 		return removedEdges;
 	}
 
-	private static optimizeSets(atn: ATN, preserveOrder: boolean): number {
+	private static _optimizeSets(atn: ATN, preserveOrder: boolean): number {
 		if (preserveOrder) {
 			// this optimization currently doesn't preserve edge order.
 			return 0;
@@ -996,7 +996,7 @@ export class ATNDeserializer {
 		return removedPaths;
 	}
 
-	private static identifyTailCalls(atn: ATN): void {
+	private static _identifyTailCalls(atn: ATN): void {
 		for (let state of atn.states) {
 			for (let i = 0; i < state.numberOfTransitions; i++) {
 				let transition = state.transition(i);
@@ -1004,8 +1004,8 @@ export class ATNDeserializer {
 					continue;
 				}
 
-				transition.tailCall = this.testTailCall(atn, transition, false);
-				transition.optimizedTailCall = this.testTailCall(atn, transition, true);
+				transition.tailCall = this._testTailCall(atn, transition, false);
+				transition.optimizedTailCall = this._testTailCall(atn, transition, true);
 			}
 
 			if (!state.isOptimized) {
@@ -1018,13 +1018,13 @@ export class ATNDeserializer {
 					continue;
 				}
 
-				transition.tailCall = this.testTailCall(atn, transition, false);
-				transition.optimizedTailCall = this.testTailCall(atn, transition, true);
+				transition.tailCall = this._testTailCall(atn, transition, false);
+				transition.optimizedTailCall = this._testTailCall(atn, transition, true);
 			}
 		}
 	}
 
-	private static testTailCall(atn: ATN, transition: RuleTransition, optimizedPath: boolean): boolean {
+	private static _testTailCall(atn: ATN, transition: RuleTransition, optimizedPath: boolean): boolean {
 		if (!optimizedPath && transition.tailCall) {
 			return true;
 		}

--- a/src/atn/ATNState.ts
+++ b/src/atn/ATNState.ts
@@ -74,7 +74,7 @@ const INITIAL_NUM_TRANSITIONS: number = 4;
  * <embed src="images/OptionalNonGreedy.svg" type="image/svg+xml"/>
  */
 export abstract class ATNState {
-	private static readonly serializationNames: string[] = [
+	private static readonly _serializationNames: string[] = [
 		"INVALID",
 		"BASIC",
 		"RULE_START",

--- a/src/atn/ATNState.ts
+++ b/src/atn/ATNState.ts
@@ -100,9 +100,9 @@ export abstract class ATNState {
 	epsilonOnlyTransitions: boolean = false;
 
 	/** Track the transitions emanating from this ATN state. */
-	protected transitions: Transition[] = [];
+	protected _transitions: Transition[] = [];
 
-	protected optimizedTransitions: Transition[] = this.transitions;
+	protected _optimizedTransitions: Transition[] = this._transitions;
 
 	/** Used to cache lookahead during parsing, not used during construction */
 	nextTokenWithinRule?: IntervalSet;
@@ -151,15 +151,15 @@ export abstract class ATNState {
 	}
 
 	getTransitions(): Transition[] {
-		return this.transitions.slice(0);
+		return this._transitions.slice(0);
 	}
 
 	get numberOfTransitions(): number {
-		return this.transitions.length;
+		return this._transitions.length;
 	}
 
 	addTransition(e: Transition, index?: number): void {
-		if (this.transitions.length === 0) {
+		if (this._transitions.length === 0) {
 			this.epsilonOnlyTransitions = e.isEpsilon;
 		}
 		else if (this.epsilonOnlyTransitions !== e.isEpsilon) {
@@ -167,19 +167,19 @@ export abstract class ATNState {
 			throw new Error("ATN state " + this.stateNumber + " has both epsilon and non-epsilon transitions.");
 		}
 
-		this.transitions.splice(index !== undefined ? index : this.transitions.length, 0, e);
+		this._transitions.splice(index !== undefined ? index : this._transitions.length, 0, e);
 	}
 
 	transition(i: number): Transition {
-		return this.transitions[i];
+		return this._transitions[i];
 	}
 
 	setTransition(i: number, e: Transition): void {
-		this.transitions[i] = e;
+		this._transitions[i] = e;
 	}
 
 	removeTransition(index: number): Transition {
-		return this.transitions.splice(index, 1)[0];
+		return this._transitions.splice(index, 1)[0];
 	}
 
 	abstract readonly stateType: ATNStateType;
@@ -193,23 +193,23 @@ export abstract class ATNState {
 	}
 
 	get isOptimized(): boolean {
-		return this.optimizedTransitions !== this.transitions;
+		return this._optimizedTransitions !== this._transitions;
 	}
 
 	get numberOfOptimizedTransitions(): number {
-		return this.optimizedTransitions.length;
+		return this._optimizedTransitions.length;
 	}
 
 	getOptimizedTransition(i: number): Transition {
-		return this.optimizedTransitions[i];
+		return this._optimizedTransitions[i];
 	}
 
 	addOptimizedTransition(e: Transition): void {
 		if (!this.isOptimized) {
-			this.optimizedTransitions = new Array<Transition>();
+			this._optimizedTransitions = new Array<Transition>();
 		}
 
-		this.optimizedTransitions.push(e);
+		this._optimizedTransitions.push(e);
 	}
 
 	setOptimizedTransition(i: number, e: Transition): void {
@@ -217,7 +217,7 @@ export abstract class ATNState {
 			throw new Error("This ATNState is not optimized.");
 		}
 
-		this.optimizedTransitions[i] = e;
+		this._optimizedTransitions[i] = e;
 	}
 
 	removeOptimizedTransition(i: number): void {
@@ -225,7 +225,7 @@ export abstract class ATNState {
 			throw new Error("This ATNState is not optimized.");
 		}
 
-		this.optimizedTransitions.splice(i, 1);
+		this._optimizedTransitions.splice(i, 1);
 	}
 }
 

--- a/src/atn/AmbiguityInfo.ts
+++ b/src/atn/AmbiguityInfo.ts
@@ -43,7 +43,7 @@ import { TokenStream } from '../TokenStream';
 export class AmbiguityInfo extends DecisionEventInfo {
 	/** The set of alternative numbers for this decision event that lead to a valid parse. */
 	@NotNull
-	private ambigAlts: BitSet;
+	private _ambigAlts: BitSet;
 
 	/**
 	 * Constructs a new instance of the {@link AmbiguityInfo} class with the
@@ -67,7 +67,7 @@ export class AmbiguityInfo extends DecisionEventInfo {
 		startIndex: number,
 		stopIndex: number) {
 		super(decision, state, input, startIndex, stopIndex, state.useContext);
-		this.ambigAlts = ambigAlts;
+		this._ambigAlts = ambigAlts;
 	}
 
 	/**
@@ -77,6 +77,6 @@ export class AmbiguityInfo extends DecisionEventInfo {
 	 */
 	@NotNull
 	get ambiguousAlternatives(): BitSet {
-		return this.ambigAlts;
+		return this._ambigAlts;
 	}
 }

--- a/src/atn/ConflictInfo.ts
+++ b/src/atn/ConflictInfo.ts
@@ -17,11 +17,11 @@ import * as Utils from '../misc/Utils';
 export class ConflictInfo {
 	private _conflictedAlts: BitSet;
 
-	private exact: boolean;
+	private _exact: boolean;
 
 	constructor(conflictedAlts: BitSet, exact: boolean) {
 		this._conflictedAlts = conflictedAlts;
-		this.exact = exact;
+		this._exact = exact;
 	}
 
 	/**
@@ -46,7 +46,7 @@ export class ConflictInfo {
 	 * states.</p>
 	 */
 	get isExact(): boolean {
-		return this.exact;
+		return this._exact;
 	}
 
 	@Override

--- a/src/atn/LexerActionExecutor.ts
+++ b/src/atn/LexerActionExecutor.ts
@@ -32,7 +32,7 @@ export class LexerActionExecutor {
 	 * Caches the result of {@link #hashCode} since the hash code is an element
 	 * of the performance-critical {@link LexerATNConfig#hashCode} operation.
 	 */
-	private cachedHashCode: number;
+	private _cachedHashCode: number;
 
 	/**
 	 * Constructs an executor for a sequence of {@link LexerAction} actions.
@@ -46,7 +46,7 @@ export class LexerActionExecutor {
 			hash = MurmurHash.update(hash, lexerAction);
 		}
 
-		this.cachedHashCode = MurmurHash.finish(hash, lexerActions.length);
+		this._cachedHashCode = MurmurHash.finish(hash, lexerActions.length);
 	}
 
 	/**
@@ -177,7 +177,7 @@ export class LexerActionExecutor {
 
 	@Override
 	hashCode(): number {
-		return this.cachedHashCode;
+		return this._cachedHashCode;
 	}
 
 	@Override
@@ -188,7 +188,7 @@ export class LexerActionExecutor {
 			return false;
 		}
 
-		return this.cachedHashCode === obj.cachedHashCode
+		return this._cachedHashCode === obj._cachedHashCode
 			&& ArrayEqualityComparator.INSTANCE.equals(this._lexerActions, obj._lexerActions);
 	}
 }

--- a/src/atn/OrderedATNConfigSet.ts
+++ b/src/atn/OrderedATNConfigSet.ts
@@ -36,13 +36,13 @@ export class OrderedATNConfigSet extends ATNConfigSet {
 	}
 
 	@Override
-	protected getKey(e: ATNConfig): { state: number, alt: number } {
+	protected _getKey(e: ATNConfig): { state: number, alt: number } {
 		// This is a specially crafted key to ensure configurations are only merged if they are equal
 		return { state: 0, alt: e.hashCode() };
 	}
 
 	@Override
-	protected canMerge(left: ATNConfig, leftKey: { state: number, alt: number }, right: ATNConfig): boolean {
+	protected _canMerge(left: ATNConfig, leftKey: { state: number, alt: number }, right: ATNConfig): boolean {
 		return left.equals(right);
 	}
 

--- a/src/atn/ParseInfo.ts
+++ b/src/atn/ParseInfo.ts
@@ -17,10 +17,10 @@ import { ProfilingATNSimulator } from './ProfilingATNSimulator';
  * @since 4.3
  */
 export class ParseInfo {
-	protected atnSimulator: ProfilingATNSimulator;
+	protected _atnSimulator: ProfilingATNSimulator;
 
 	constructor(@NotNull atnSimulator: ProfilingATNSimulator) {
-		this.atnSimulator = atnSimulator;
+		this._atnSimulator = atnSimulator;
 	}
 
 	/**
@@ -32,7 +32,7 @@ export class ParseInfo {
 	 */
 	@NotNull
 	getDecisionInfo(): DecisionInfo[] {
-		return this.atnSimulator.getDecisionInfo();
+		return this._atnSimulator.getDecisionInfo();
 	}
 
 	/**
@@ -45,7 +45,7 @@ export class ParseInfo {
 	 */
 	@NotNull
 	getLLDecisions(): number[] {
-		let decisions: DecisionInfo[] = this.atnSimulator.getDecisionInfo();
+		let decisions: DecisionInfo[] = this._atnSimulator.getDecisionInfo();
 		let LL: number[] = [];
 		for (let i = 0; i < decisions.length; i++) {
 			let fallBack: number = decisions[i].LL_Fallback;
@@ -63,7 +63,7 @@ export class ParseInfo {
 	 * {@link DecisionInfo#timeInPrediction} for all decisions.
 	 */
 	getTotalTimeInPrediction(): number {
-		let decisions: DecisionInfo[] = this.atnSimulator.getDecisionInfo();
+		let decisions: DecisionInfo[] = this._atnSimulator.getDecisionInfo();
 		let t: number = 0;
 		for (let i = 0; i < decisions.length; i++) {
 			t += decisions[i].timeInPrediction;
@@ -78,7 +78,7 @@ export class ParseInfo {
 	 * {@link DecisionInfo#SLL_TotalLook} for all decisions.
 	 */
 	getTotalSLLLookaheadOps(): number {
-		let decisions: DecisionInfo[] = this.atnSimulator.getDecisionInfo();
+		let decisions: DecisionInfo[] = this._atnSimulator.getDecisionInfo();
 		let k: number = 0;
 		for (let i = 0; i < decisions.length; i++) {
 			k += decisions[i].SLL_TotalLook;
@@ -93,7 +93,7 @@ export class ParseInfo {
 	 * {@link DecisionInfo#LL_TotalLook} for all decisions.
 	 */
 	getTotalLLLookaheadOps(): number {
-		let decisions: DecisionInfo[] = this.atnSimulator.getDecisionInfo();
+		let decisions: DecisionInfo[] = this._atnSimulator.getDecisionInfo();
 		let k: number = 0;
 		for (let i = 0; i < decisions.length; i++) {
 			k += decisions[i].LL_TotalLook;
@@ -107,7 +107,7 @@ export class ParseInfo {
 	 * across all decisions made during parsing.
 	 */
 	getTotalSLLATNLookaheadOps(): number {
-		let decisions: DecisionInfo[] = this.atnSimulator.getDecisionInfo();
+		let decisions: DecisionInfo[] = this._atnSimulator.getDecisionInfo();
 		let k: number = 0;
 		for (let i = 0; i < decisions.length; i++) {
 			k += decisions[i].SLL_ATNTransitions;
@@ -121,7 +121,7 @@ export class ParseInfo {
 	 * across all decisions made during parsing.
 	 */
 	getTotalLLATNLookaheadOps(): number {
-		let decisions: DecisionInfo[] = this.atnSimulator.getDecisionInfo();
+		let decisions: DecisionInfo[] = this._atnSimulator.getDecisionInfo();
 		let k: number = 0;
 		for (let i = 0; i < decisions.length; i++) {
 			k += decisions[i].LL_ATNTransitions;
@@ -139,7 +139,7 @@ export class ParseInfo {
 	 * {@link #getTotalLLATNLookaheadOps}.</p>
 	 */
 	getTotalATNLookaheadOps(): number {
-		let decisions: DecisionInfo[] = this.atnSimulator.getDecisionInfo();
+		let decisions: DecisionInfo[] = this._atnSimulator.getDecisionInfo();
 		let k: number = 0;
 		for (let i = 0; i < decisions.length; i++) {
 			k += decisions[i].SLL_ATNTransitions;
@@ -163,11 +163,11 @@ export class ParseInfo {
 
 	getDFASize(decision?: number): number {
 		if (decision) {
-			let decisionToDFA: DFA = this.atnSimulator.atn.decisionToDFA[decision];
+			let decisionToDFA: DFA = this._atnSimulator.atn.decisionToDFA[decision];
 			return decisionToDFA.states.size;
 		} else {
 			let n: number = 0;
-			let decisionToDFA: DFA[] = this.atnSimulator.atn.decisionToDFA;
+			let decisionToDFA: DFA[] = this._atnSimulator.atn.decisionToDFA;
 			for (let i = 0; i < decisionToDFA.length; i++) {
 				n += this.getDFASize(i);
 			}

--- a/src/atn/ParserATNSimulator.ts
+++ b/src/atn/ParserATNSimulator.ts
@@ -290,7 +290,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	static retry_debug: boolean = false;
 
 	@NotNull
-	private predictionMode: PredictionMode = PredictionMode.LL;
+	private _predictionMode: PredictionMode = PredictionMode.LL;
 	force_global_context: boolean = false;
 	always_try_local_context: boolean = true;
 
@@ -337,7 +337,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	 */
 	protected userWantsCtxSensitive: boolean = true;
 
-	private dfa?: DFA;
+	private _dfa?: DFA;
 
 	constructor(@NotNull atn: ATN, parser: Parser) {
 		super(atn);
@@ -346,11 +346,11 @@ export class ParserATNSimulator extends ATNSimulator {
 
 	@NotNull
 	getPredictionMode(): PredictionMode {
-		return this.predictionMode;
+		return this._predictionMode;
 	}
 
 	setPredictionMode(@NotNull predictionMode: PredictionMode): void {
-		this.predictionMode = predictionMode;
+		this._predictionMode = predictionMode;
 	}
 
 	@Override
@@ -380,7 +380,7 @@ export class ParserATNSimulator extends ATNSimulator {
 			}
 		}
 
-		this.dfa = dfa;
+		this._dfa = dfa;
 
 		if (this.force_global_context) {
 			useContext = true;
@@ -389,7 +389,7 @@ export class ParserATNSimulator extends ATNSimulator {
 			useContext = useContext || dfa.isContextSensitive;
 		}
 
-		this.userWantsCtxSensitive = useContext || (this.predictionMode !== PredictionMode.SLL && outerContext != null && !this.atn.decisionToState[decision].sll);
+		this.userWantsCtxSensitive = useContext || (this._predictionMode !== PredictionMode.SLL && outerContext != null && !this.atn.decisionToState[decision].sll);
 		if (outerContext == null) {
 			outerContext = ParserRuleContext.emptyContext();
 		}
@@ -416,7 +416,7 @@ export class ParserATNSimulator extends ATNSimulator {
 			return alt;
 		}
 		finally {
-			this.dfa = undefined;
+			this._dfa = undefined;
 			input.seek(index);
 			input.release(m);
 		}
@@ -626,7 +626,7 @@ export class ParserATNSimulator extends ATNSimulator {
 				input.seek(startIndex);
 			}
 
-			let alts: BitSet = this.evalSemanticContext(predicates, outerContext, this.reportAmbiguities && this.predictionMode === PredictionMode.LL_EXACT_AMBIG_DETECTION);
+			let alts: BitSet = this.evalSemanticContext(predicates, outerContext, this.reportAmbiguities && this._predictionMode === PredictionMode.LL_EXACT_AMBIG_DETECTION);
 			switch (alts.cardinality()) {
 			case 0:
 				throw this.noViableAlt(input, outerContext, s.configs, startIndex);
@@ -685,7 +685,7 @@ export class ParserATNSimulator extends ATNSimulator {
 		}
 
 		// More picky when we need exact conflicts
-		if (useContext && this.predictionMode === PredictionMode.LL_EXACT_AMBIG_DETECTION) {
+		if (useContext && this._predictionMode === PredictionMode.LL_EXACT_AMBIG_DETECTION) {
 			return state.configs.isExactConflict;
 		}
 
@@ -1825,9 +1825,9 @@ export class ParserATNSimulator extends ATNSimulator {
 						continue;
 					}
 
-					if (this.dfa != null && this.dfa.isPrecedenceDfa) {
+					if (this._dfa != null && this._dfa.isPrecedenceDfa) {
 						let outermostPrecedenceReturn: number = (<EpsilonTransition>t).outermostPrecedenceReturn;
-						if (outermostPrecedenceReturn == this.dfa.atnStartState.ruleIndex) {
+						if (outermostPrecedenceReturn == this._dfa.atnStartState.ruleIndex) {
 							c.isPrecedenceFilterSuppressed = true;
 						}
 					}
@@ -1991,7 +1991,7 @@ export class ParserATNSimulator extends ATNSimulator {
 		return config.transform(t.target, false, newContext);
 	}
 
-	private static STATE_ALT_SORT_COMPARATOR: (o1: ATNConfig, o2: ATNConfig) => number =
+	private static _STATE_ALT_SORT_COMPARATOR: (o1: ATNConfig, o2: ATNConfig) => number =
 		(o1: ATNConfig, o2: ATNConfig): number => {
 			let diff: number = o1.state.nonStopStateNumber - o2.state.nonStopStateNumber;
 			if (diff !== 0) {
@@ -2006,13 +2006,13 @@ export class ParserATNSimulator extends ATNSimulator {
 			return 0;
 		};
 
-	private isConflicted(@NotNull configset: ATNConfigSet, contextCache: PredictionContextCache): ConflictInfo | undefined {
+	private _isConflicted(@NotNull configset: ATNConfigSet, contextCache: PredictionContextCache): ConflictInfo | undefined {
 		if (configset.uniqueAlt !== ATN.INVALID_ALT_NUMBER || configset.size <= 1) {
 			return undefined;
 		}
 
 		let configs: ATNConfig[] = configset.toArray();
-		configs.sort(ParserATNSimulator.STATE_ALT_SORT_COMPARATOR);
+		configs.sort(ParserATNSimulator._STATE_ALT_SORT_COMPARATOR);
 
 		let exact: boolean = !configset.dipsIntoOuterContext;
 		let alts: BitSet = new BitSet();
@@ -2331,7 +2331,7 @@ export class ParserATNSimulator extends ATNSimulator {
 
 		if (!configs.isReadOnly) {
 			if (configs.conflictInfo == null) {
-				configs.conflictInfo = this.isConflicted(configs, contextCache);
+				configs.conflictInfo = this._isConflicted(configs, contextCache);
 			}
 		}
 

--- a/src/atn/ParserATNSimulator.ts
+++ b/src/atn/ParserATNSimulator.ts
@@ -335,7 +335,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	 *  when closure operations fall off the end of the rule that
 	 *  holds the decision were evaluating.
 	 */
-	protected userWantsCtxSensitive: boolean = true;
+	protected _userWantsCtxSensitive: boolean = true;
 
 	private _dfa?: DFA;
 
@@ -389,14 +389,14 @@ export class ParserATNSimulator extends ATNSimulator {
 			useContext = useContext || dfa.isContextSensitive;
 		}
 
-		this.userWantsCtxSensitive = useContext || (this._predictionMode !== PredictionMode.SLL && outerContext != null && !this.atn.decisionToState[decision].sll);
+		this._userWantsCtxSensitive = useContext || (this._predictionMode !== PredictionMode.SLL && outerContext != null && !this.atn.decisionToState[decision].sll);
 		if (outerContext == null) {
 			outerContext = ParserRuleContext.emptyContext();
 		}
 
 		let state: SimulatorState | undefined;
 		if (!dfa.isEmpty) {
-			state = this.getStartState(dfa, input, outerContext, useContext);
+			state = this._getStartState(dfa, input, outerContext, useContext);
 		}
 
 		if (state == null) {
@@ -405,13 +405,13 @@ export class ParserATNSimulator extends ATNSimulator {
 				" exec LA(1)==" + this.getLookaheadName(input) +
 				", outerContext=" + outerContext.toString(this._parser));
 
-			state = this.computeStartState(dfa, outerContext, useContext);
+			state = this._computeStartState(dfa, outerContext, useContext);
 		}
 
 		let m: number = input.mark();
 		let index: number = input.index;
 		try {
-			let alt: number = this.execDFA(dfa, input, index, state);
+			let alt: number = this._execDFA(dfa, input, index, state);
 			if (ParserATNSimulator.debug) console.log("DFA after predictATN: " + dfa.toString(this._parser.vocabulary, this._parser.ruleNames));
 			return alt;
 		}
@@ -422,7 +422,7 @@ export class ParserATNSimulator extends ATNSimulator {
 		}
 	}
 
-	protected getStartState(@NotNull dfa: DFA,
+	protected _getStartState(@NotNull dfa: DFA,
 		@NotNull input: TokenStream,
 		@NotNull outerContext: ParserRuleContext,
 		useContext: boolean): SimulatorState | undefined {
@@ -462,8 +462,8 @@ export class ParserATNSimulator extends ATNSimulator {
 		}
 
 		while (remainingContext != null && s0 != null && s0.isContextSensitive) {
-			remainingContext = this.skipTailCalls(remainingContext);
-			s0 = s0.getContextTarget(this.getReturnState(remainingContext));
+			remainingContext = this._skipTailCalls(remainingContext);
+			s0 = s0.getContextTarget(this._getReturnState(remainingContext));
 			if (remainingContext.isEmpty) {
 				assert(s0 == null || !s0.isContextSensitive);
 			}
@@ -479,7 +479,7 @@ export class ParserATNSimulator extends ATNSimulator {
 		return new SimulatorState(outerContext, s0, useContext, remainingContext);
 	}
 
-	protected execDFA(@NotNull dfa: DFA,
+	protected _execDFA(@NotNull dfa: DFA,
 					   @NotNull input: TokenStream, startIndex: number,
 					   @NotNull state: SimulatorState): number {
 		let outerContext: ParserRuleContext = state.outerContext;
@@ -498,14 +498,14 @@ export class ParserATNSimulator extends ATNSimulator {
 				while (s.isContextSymbol(t)) {
 					let next: DFAState | undefined;
 					if (remainingOuterContext != null) {
-						remainingOuterContext = this.skipTailCalls(remainingOuterContext);
-						next = s.getContextTarget(this.getReturnState(remainingOuterContext));
+						remainingOuterContext = this._skipTailCalls(remainingOuterContext);
+						next = s.getContextTarget(this._getReturnState(remainingOuterContext));
 					}
 
 					if (next == null) {
 						// fail over to ATN
 						let initialState: SimulatorState = new SimulatorState(state.outerContext, s, state.useContext, remainingOuterContext);
-						return this.execATN(dfa, input, startIndex, initialState);
+						return this._execATN(dfa, input, startIndex, initialState);
 					}
 
 					assert(remainingOuterContext != null);
@@ -514,7 +514,7 @@ export class ParserATNSimulator extends ATNSimulator {
 				}
 			}
 
-			if (this.isAcceptState(s, state.useContext)) {
+			if (this._isAcceptState(s, state.useContext)) {
 				if (s.predicates != null) {
 					if (ParserATNSimulator.dfa_debug) console.log("accept " + s);
 				}
@@ -530,10 +530,10 @@ export class ParserATNSimulator extends ATNSimulator {
 			}
 
 			// t is not updated if one of these states is reached
-			assert(!this.isAcceptState(s, state.useContext));
+			assert(!this._isAcceptState(s, state.useContext));
 
 			// if no edge, pop over to ATN interpreter, update DFA and return
-			let target: DFAState | undefined = this.getExistingTargetState(s, t);
+			let target: DFAState | undefined = this._getExistingTargetState(s, t);
 			if (target == null) {
 				if (ParserATNSimulator.dfa_debug && t >= 0) console.log("no edge for " + this._parser.vocabulary.getDisplayName(t));
 				let alt: number;
@@ -545,7 +545,7 @@ export class ParserATNSimulator extends ATNSimulator {
 				}
 
 				let initialState: SimulatorState = new SimulatorState(outerContext, s, state.useContext, remainingOuterContext);
-				alt = this.execATN(dfa, input, startIndex, initialState);
+				alt = this._execATN(dfa, input, startIndex, initialState);
 				if (ParserATNSimulator.dfa_debug) {
 					console.log("back from DFA update, alt=" + alt + ", dfa=\n" + dfa.toString(this._parser.vocabulary, this._parser.ruleNames));
 					//dump(dfa);
@@ -557,10 +557,10 @@ export class ParserATNSimulator extends ATNSimulator {
 			}
 			else if (target === ATNSimulator.ERROR) {
 				let errorState: SimulatorState = new SimulatorState(outerContext, s, state.useContext, remainingOuterContext);
-				return this.handleNoViableAlt(input, startIndex, errorState);
+				return this._handleNoViableAlt(input, startIndex, errorState);
 			}
 			s = target;
-			if (!this.isAcceptState(s, state.useContext) && t !== IntStream.EOF) {
+			if (!this._isAcceptState(s, state.useContext) && t !== IntStream.EOF) {
 				input.consume();
 				t = input.LA(1);
 			}
@@ -572,7 +572,7 @@ export class ParserATNSimulator extends ATNSimulator {
 
 		if (!state.useContext && s.configs.conflictInfo != null) {
 			if (dfa.atnStartState instanceof DecisionState) {
-				if (!this.userWantsCtxSensitive ||
+				if (!this._userWantsCtxSensitive ||
 					(!s.configs.dipsIntoOuterContext && s.configs.isExactConflict) ||
 					(this.treat_sllk1_conflict_as_ambiguity && input.index === startIndex)) {
 					// we don't report the ambiguity again
@@ -594,7 +594,7 @@ export class ParserATNSimulator extends ATNSimulator {
 							input.seek(startIndex);
 						}
 
-						conflictingAlts = this.evalSemanticContext(predicates, outerContext, true);
+						conflictingAlts = this._evalSemanticContext(predicates, outerContext, true);
 						if (conflictingAlts.cardinality() === 1) {
 							return conflictingAlts.nextSetBit(0);
 						}
@@ -608,7 +608,7 @@ export class ParserATNSimulator extends ATNSimulator {
 
 					if (this.reportAmbiguities) {
 						let conflictState: SimulatorState = new SimulatorState(outerContext, s, state.useContext, remainingOuterContext);
-						this.reportAttemptingFullContext(dfa, conflictingAlts, conflictState, startIndex, input.index);
+						this._reportAttemptingFullContext(dfa, conflictingAlts, conflictState, startIndex, input.index);
 					}
 
 					input.seek(startIndex);
@@ -626,10 +626,10 @@ export class ParserATNSimulator extends ATNSimulator {
 				input.seek(startIndex);
 			}
 
-			let alts: BitSet = this.evalSemanticContext(predicates, outerContext, this.reportAmbiguities && this._predictionMode === PredictionMode.LL_EXACT_AMBIG_DETECTION);
+			let alts: BitSet = this._evalSemanticContext(predicates, outerContext, this.reportAmbiguities && this._predictionMode === PredictionMode.LL_EXACT_AMBIG_DETECTION);
 			switch (alts.cardinality()) {
 			case 0:
-				throw this.noViableAlt(input, outerContext, s.configs, startIndex);
+				throw this._noViableAlt(input, outerContext, s.configs, startIndex);
 
 			case 1:
 				return alts.nextSetBit(0);
@@ -641,7 +641,7 @@ export class ParserATNSimulator extends ATNSimulator {
 					input.seek(stopIndex);
 				}
 
-				this.reportAmbiguity(dfa, s, startIndex, stopIndex, s.configs.isExactConflict, alts, s.configs);
+				this._reportAmbiguity(dfa, s, startIndex, stopIndex, s.configs.isExactConflict, alts, s.configs);
 				return alts.nextSetBit(0);
 			}
 		}
@@ -674,7 +674,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	 * @return {@code true} if the specified {@code state} is an accept state;
 	 * otherwise, {@code false}.
 	 */
-	protected isAcceptState(state: DFAState, useContext: boolean): boolean {
+	protected _isAcceptState(state: DFAState, useContext: boolean): boolean {
 		if (!state.isAcceptState) {
 			return false;
 		}
@@ -735,7 +735,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	 TODO: greedy + those
 
 	 */
-	protected execATN(@NotNull dfa: DFA,
+	protected _execATN(@NotNull dfa: DFA,
 					   @NotNull input: TokenStream, startIndex: number,
 					   @NotNull initialState: SimulatorState): number {
 		if (ParserATNSimulator.debug) console.log("execATN decision " + dfa.decision + " exec LA(1)==" + this.getLookaheadName(input));
@@ -749,10 +749,10 @@ export class ParserATNSimulator extends ATNSimulator {
 
 		let contextCache: PredictionContextCache = new PredictionContextCache();
 		while (true) { // while more work
-			let nextState: SimulatorState | undefined = this.computeReachSet(dfa, previous, t, contextCache);
+			let nextState: SimulatorState | undefined = this._computeReachSet(dfa, previous, t, contextCache);
 			if (nextState == null) {
-				this.setDFAEdge(previous.s0, input.LA(1), ATNSimulator.ERROR);
-				return this.handleNoViableAlt(input, startIndex, previous);
+				this._setDFAEdge(previous.s0, input.LA(1), ATNSimulator.ERROR);
+				return this._handleNoViableAlt(input, startIndex, previous);
 			}
 
 			let D: DFAState = nextState.s0;
@@ -762,7 +762,7 @@ export class ParserATNSimulator extends ATNSimulator {
 			// conflicted => accept state
 			assert(D.isAcceptState || D.configs.conflictInfo == null);
 
-			if (this.isAcceptState(D, useContext)) {
+			if (this._isAcceptState(D, useContext)) {
 				let conflictingAlts: BitSet | undefined = D.configs.conflictingAlts;
 				let predictedAlt: number = conflictingAlts == null ? D.prediction : ATN.INVALID_ALT_NUMBER;
 				if (predictedAlt !== ATN.INVALID_ALT_NUMBER) {
@@ -779,14 +779,14 @@ export class ParserATNSimulator extends ATNSimulator {
 					}
 
 					if (useContext && this.always_try_local_context) {
-						this.reportContextSensitivity(dfa, predictedAlt, nextState, startIndex, input.index);
+						this._reportContextSensitivity(dfa, predictedAlt, nextState, startIndex, input.index);
 					}
 				}
 
 				predictedAlt = D.prediction;
 //				int k = input.index - startIndex + 1; // how much input we used
 //				System.out.println("used k="+k);
-				let attemptFullContext: boolean = conflictingAlts != null && this.userWantsCtxSensitive;
+				let attemptFullContext: boolean = conflictingAlts != null && this._userWantsCtxSensitive;
 				if (attemptFullContext) {
 					// Only exact conflicts are known to be ambiguous when local
 					// prediction does not step out of the decision rule.
@@ -804,10 +804,10 @@ export class ParserATNSimulator extends ATNSimulator {
 						}
 
 						// use complete evaluation here if we'll want to retry with full context if still ambiguous
-						conflictingAlts = this.evalSemanticContext(predPredictions, outerContext, attemptFullContext || this.reportAmbiguities);
+						conflictingAlts = this._evalSemanticContext(predPredictions, outerContext, attemptFullContext || this.reportAmbiguities);
 						switch (conflictingAlts.cardinality()) {
 						case 0:
-							throw this.noViableAlt(input, outerContext, D.configs, startIndex);
+							throw this._noViableAlt(input, outerContext, D.configs, startIndex);
 
 						case 1:
 							return conflictingAlts.nextSetBit(0);
@@ -827,7 +827,7 @@ export class ParserATNSimulator extends ATNSimulator {
 				if (!attemptFullContext) {
 					if (conflictingAlts != null) {
 						if (this.reportAmbiguities && conflictingAlts.cardinality() > 1) {
-							this.reportAmbiguity(dfa, D, startIndex, input.index, D.configs.isExactConflict, conflictingAlts, D.configs);
+							this._reportAmbiguity(dfa, D, startIndex, input.index, D.configs.isExactConflict, conflictingAlts, D.configs);
 						}
 
 						predictedAlt = conflictingAlts.nextSetBit(0);
@@ -837,16 +837,16 @@ export class ParserATNSimulator extends ATNSimulator {
 				}
 				else {
 					assert(!useContext);
-					assert(this.isAcceptState(D, false));
+					assert(this._isAcceptState(D, false));
 
 					if (ParserATNSimulator.debug) console.log("RETRY with outerContext=" + outerContext);
-					let fullContextState: SimulatorState = this.computeStartState(dfa, outerContext, true);
+					let fullContextState: SimulatorState = this._computeStartState(dfa, outerContext, true);
 					if (this.reportAmbiguities) {
-						this.reportAttemptingFullContext(dfa, conflictingAlts, nextState, startIndex, input.index);
+						this._reportAttemptingFullContext(dfa, conflictingAlts, nextState, startIndex, input.index);
 					}
 
 					input.seek(startIndex);
-					return this.execATN(dfa, input, startIndex, fullContextState);
+					return this._execATN(dfa, input, startIndex, fullContextState);
 				}
 			}
 
@@ -917,7 +917,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	 * {@link ATN#INVALID_ALT_NUMBER} if a suitable alternative was not
 	 * identified and {@link #adaptivePredict} should report an error instead.
 	 */
-	protected handleNoViableAlt(@NotNull input: TokenStream, startIndex: number, @NotNull previous: SimulatorState): number {
+	protected _handleNoViableAlt(@NotNull input: TokenStream, startIndex: number, @NotNull previous: SimulatorState): number {
 		if (previous.s0 != null) {
 			let alts: BitSet = new BitSet();
 			let maxAlt: number = 0;
@@ -961,14 +961,14 @@ export class ParserATNSimulator extends ATNSimulator {
 				 *     filteredConfigs, rather than restricting the evaluation to
 				 *     conflicting and/or unique configurations.
 				 */
-				let altToPred: SemanticContext[] | undefined = this.getPredsForAmbigAlts(alts, filteredConfigs, maxAlt);
+				let altToPred: SemanticContext[] | undefined = this._getPredsForAmbigAlts(alts, filteredConfigs, maxAlt);
 				if (altToPred != null) {
-					let predicates: DFAState.PredPrediction[] | undefined = this.getPredicatePredictions(alts, altToPred);
+					let predicates: DFAState.PredPrediction[] | undefined = this._getPredicatePredictions(alts, altToPred);
 					if (predicates != null) {
 						let stopIndex: number = input.index;
 						try {
 							input.seek(startIndex);
-							let filteredAlts: BitSet = this.evalSemanticContext(predicates, previous.outerContext, false);
+							let filteredAlts: BitSet = this._evalSemanticContext(predicates, previous.outerContext, false);
 							if (!filteredAlts.isEmpty) {
 								return filteredAlts.nextSetBit(0);
 							}
@@ -983,10 +983,10 @@ export class ParserATNSimulator extends ATNSimulator {
 			}
 		}
 
-		throw this.noViableAlt(input, previous.outerContext, previous.s0.configs, startIndex);
+		throw this._noViableAlt(input, previous.outerContext, previous.s0.configs, startIndex);
 	}
 
-	protected computeReachSet(dfa: DFA, previous: SimulatorState, t: number, contextCache: PredictionContextCache): SimulatorState | undefined {
+	protected _computeReachSet(dfa: DFA, previous: SimulatorState, t: number, contextCache: PredictionContextCache): SimulatorState | undefined {
 		let useContext: boolean = previous.useContext;
 		let remainingGlobalContext: ParserRuleContext | undefined = previous.remainingOuterContext;
 
@@ -995,8 +995,8 @@ export class ParserATNSimulator extends ATNSimulator {
 			while (s.isContextSymbol(t)) {
 				let next: DFAState | undefined;
 				if (remainingGlobalContext != null) {
-					remainingGlobalContext = this.skipTailCalls(remainingGlobalContext);
-					next = s.getContextTarget(this.getReturnState(remainingGlobalContext));
+					remainingGlobalContext = this._skipTailCalls(remainingGlobalContext);
+					next = s.getContextTarget(this._getReturnState(remainingGlobalContext));
 				}
 
 				if (next == null) {
@@ -1009,16 +1009,16 @@ export class ParserATNSimulator extends ATNSimulator {
 			}
 		}
 
-		assert(!this.isAcceptState(s, useContext));
-		if (this.isAcceptState(s, useContext)) {
+		assert(!this._isAcceptState(s, useContext));
+		if (this._isAcceptState(s, useContext)) {
 			return new SimulatorState(previous.outerContext, s, useContext, remainingGlobalContext);
 		}
 
 		let s0: DFAState = s;
 
-		let target: DFAState | undefined = this.getExistingTargetState(s0, t);
+		let target: DFAState | undefined = this._getExistingTargetState(s0, t);
 		if (target == null) {
-			let result: [DFAState, ParserRuleContext | undefined] = this.computeTargetState(dfa, s0, remainingGlobalContext, t, useContext, contextCache);
+			let result: [DFAState, ParserRuleContext | undefined] = this._computeTargetState(dfa, s0, remainingGlobalContext, t, useContext, contextCache);
 			target = result[0];
 			remainingGlobalContext = result[1];
 		}
@@ -1042,7 +1042,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	 * {@code t}, or {@code null} if the target state for this edge is not
 	 * already cached
 	 */
-	protected getExistingTargetState(@NotNull s: DFAState, t: number): DFAState | undefined {
+	protected _getExistingTargetState(@NotNull s: DFAState, t: number): DFAState | undefined {
 		return s.getTarget(t);
 	}
 
@@ -1062,7 +1062,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	 * returns {@link #ERROR}.
 	 */
 	@NotNull
-	protected computeTargetState(@NotNull dfa: DFA, @NotNull s: DFAState, remainingGlobalContext: ParserRuleContext | undefined, t: number, useContext: boolean, contextCache: PredictionContextCache): [DFAState, ParserRuleContext | undefined] {
+	protected _computeTargetState(@NotNull dfa: DFA, @NotNull s: DFAState, remainingGlobalContext: ParserRuleContext | undefined, t: number, useContext: boolean, contextCache: PredictionContextCache): [DFAState, ParserRuleContext | undefined] {
 		let closureConfigs: ATNConfig[] = s.configs.toArray();
 		let contextElements: IntegerList | undefined;
 		let reach: ATNConfigSet = new ATNConfigSet();
@@ -1106,7 +1106,7 @@ export class ParserATNSimulator extends ATNSimulator {
 				let n: number = c.state.numberOfOptimizedTransitions;
 				for (let ti = 0; ti < n; ti++) {               // for each optimized transition
 					let trans: Transition = c.state.getOptimizedTransition(ti);
-					let target: ATNState | undefined = this.getReachableTarget(c, trans, t);
+					let target: ATNState | undefined = this._getReachableTarget(c, trans, t);
 					if (target != null) {
 						reachIntermediate.add(c.transform(target, false), contextCache);
 					}
@@ -1133,7 +1133,7 @@ export class ParserATNSimulator extends ATNSimulator {
 			 */
 			let collectPredicates: boolean = false;
 			let treatEofAsEpsilon: boolean = t === Token.EOF;
-			this.closure(reachIntermediate, reach, collectPredicates, hasMoreContext, contextCache, treatEofAsEpsilon);
+			this._closure(reachIntermediate, reach, collectPredicates, hasMoreContext, contextCache, treatEofAsEpsilon);
 			stepIntoGlobal = reach.dipsIntoOuterContext;
 
 			if (t === IntStream.EOF) {
@@ -1149,7 +1149,7 @@ export class ParserATNSimulator extends ATNSimulator {
 				 * already guaranteed to meet this condition whether or not it's
 				 * required.
 				 */
-				reach = this.removeAllConfigsNotInRuleStopState(reach, contextCache);
+				reach = this._removeAllConfigsNotInRuleStopState(reach, contextCache);
 			}
 
 			/* If skippedStopStates is not null, then it contains at least one
@@ -1173,8 +1173,8 @@ export class ParserATNSimulator extends ATNSimulator {
 				// We know remainingGlobalContext is not undefined at this point (why?)
 				remainingGlobalContext = <ParserRuleContext>remainingGlobalContext;
 
-				remainingGlobalContext = this.skipTailCalls(remainingGlobalContext);
-				let nextContextElement: number = this.getReturnState(remainingGlobalContext);
+				remainingGlobalContext = this._skipTailCalls(remainingGlobalContext);
+				let nextContextElement: number = this._getReturnState(remainingGlobalContext);
 				if (contextElements == null) {
 					contextElements = new IntegerList();
 				}
@@ -1195,11 +1195,11 @@ export class ParserATNSimulator extends ATNSimulator {
 		} while (useContext && stepIntoGlobal);
 
 		if (reach.isEmpty) {
-			this.setDFAEdge(s, t, ATNSimulator.ERROR);
+			this._setDFAEdge(s, t, ATNSimulator.ERROR);
 			return [ATNSimulator.ERROR, remainingGlobalContext];
 		}
 
-		let result: DFAState = this.addDFAEdge(dfa, s, t, contextElements, reach, contextCache);
+		let result: DFAState = this._addDFAEdge(dfa, s, t, contextElements, reach, contextCache);
 		return [result, remainingGlobalContext];
 	}
 
@@ -1217,7 +1217,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	 * the configurations from {@code configs} which are in a rule stop state
 	 */
 	@NotNull
-	protected removeAllConfigsNotInRuleStopState(@NotNull configs: ATNConfigSet, contextCache: PredictionContextCache): ATNConfigSet {
+	protected _removeAllConfigsNotInRuleStopState(@NotNull configs: ATNConfigSet, contextCache: PredictionContextCache): ATNConfigSet {
 		if (PredictionMode.allConfigsInRuleStopStates(configs)) {
 			return configs;
 		}
@@ -1235,7 +1235,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	}
 
 	@NotNull
-	protected computeStartState(dfa: DFA,
+	protected _computeStartState(dfa: DFA,
 		globalContext: ParserRuleContext,
 		useContext: boolean): SimulatorState {
 		let s0: DFAState | undefined =
@@ -1267,7 +1267,7 @@ export class ParserATNSimulator extends ATNSimulator {
 						remainingGlobalContext = undefined;
 					}
 					else {
-						previousContext = this.getReturnState(remainingGlobalContext);
+						previousContext = this._getReturnState(remainingGlobalContext);
 						initialContext = initialContext.appendSingleContext(previousContext, contextCache);
 						remainingGlobalContext = remainingGlobalContext.parent;
 					}
@@ -1276,14 +1276,14 @@ export class ParserATNSimulator extends ATNSimulator {
 
 			while (s0 != null && s0.isContextSensitive && remainingGlobalContext != null) {
 				let next: DFAState | undefined;
-				remainingGlobalContext = this.skipTailCalls(remainingGlobalContext);
+				remainingGlobalContext = this._skipTailCalls(remainingGlobalContext);
 				if (remainingGlobalContext.isEmpty) {
 					next = s0.getContextTarget(PredictionContext.EMPTY_FULL_STATE_KEY);
 					previousContext = PredictionContext.EMPTY_FULL_STATE_KEY;
 					remainingGlobalContext = undefined;
 				}
 				else {
-					previousContext = this.getReturnState(remainingGlobalContext);
+					previousContext = this._getReturnState(remainingGlobalContext);
 					next = s0.getContextTarget(previousContext);
 					initialContext = initialContext.appendSingleContext(previousContext, contextCache);
 					remainingGlobalContext = remainingGlobalContext.parent;
@@ -1317,17 +1317,17 @@ export class ParserATNSimulator extends ATNSimulator {
 			}
 
 			let collectPredicates: boolean = true;
-			this.closure(reachIntermediate, configs, collectPredicates, hasMoreContext, contextCache, false);
+			this._closure(reachIntermediate, configs, collectPredicates, hasMoreContext, contextCache, false);
 			let stepIntoGlobal: boolean = configs.dipsIntoOuterContext;
 
 			let next: DFAState;
 			if (useContext && !this.enable_global_context_dfa) {
-				s0 = this.addDFAState(dfa, configs, contextCache);
+				s0 = this._addDFAState(dfa, configs, contextCache);
 				break;
 			}
 			else if (s0 == null) {
 				if (!dfa.isPrecedenceDfa) {
-					next = this.addDFAState(dfa, configs, contextCache);
+					next = this._addDFAState(dfa, configs, contextCache);
 					if (useContext) {
 						if (!dfa.s0full) {
 							dfa.s0full = next;
@@ -1349,17 +1349,17 @@ export class ParserATNSimulator extends ATNSimulator {
 					 * appropriate start state for the precedence level rather
 					 * than simply setting DFA.s0.
 					 */
-					configs = this.applyPrecedenceFilter(configs, globalContext, contextCache);
-					next = this.addDFAState(dfa, configs, contextCache);
+					configs = this._applyPrecedenceFilter(configs, globalContext, contextCache);
+					next = this._addDFAState(dfa, configs, contextCache);
 					dfa.setPrecedenceStartState(this._parser.precedence, useContext, next);
 				}
 			}
 			else {
 				if (dfa.isPrecedenceDfa) {
-					configs = this.applyPrecedenceFilter(configs, globalContext, contextCache);
+					configs = this._applyPrecedenceFilter(configs, globalContext, contextCache);
 				}
 
-				next = this.addDFAState(dfa, configs, contextCache);
+				next = this._addDFAState(dfa, configs, contextCache);
 				s0.setContextTarget(previousContext, next);
 			}
 
@@ -1376,8 +1376,8 @@ export class ParserATNSimulator extends ATNSimulator {
 			remainingGlobalContext = <ParserRuleContext>remainingGlobalContext;
 
 			configs.clear();
-			remainingGlobalContext = this.skipTailCalls(remainingGlobalContext);
-			let nextContextElement: number = this.getReturnState(remainingGlobalContext);
+			remainingGlobalContext = this._skipTailCalls(remainingGlobalContext);
+			let nextContextElement: number = this._getReturnState(remainingGlobalContext);
 
 			if (remainingGlobalContext.isEmpty) {
 				remainingGlobalContext = undefined;
@@ -1456,7 +1456,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	 * calling {@link Parser#getPrecedence}).
 	 */
 	@NotNull
-	protected applyPrecedenceFilter(@NotNull configs: ATNConfigSet, globalContext: ParserRuleContext, contextCache: PredictionContextCache): ATNConfigSet {
+	protected _applyPrecedenceFilter(@NotNull configs: ATNConfigSet, globalContext: ParserRuleContext, contextCache: PredictionContextCache): ATNConfigSet {
 		let statesFromAlt1: Map<number, PredictionContext> = new Map<number, PredictionContext>();
 		let configSet: ATNConfigSet = new ATNConfigSet();
 		for (let config of asIterable(configs)) {
@@ -1504,7 +1504,7 @@ export class ParserATNSimulator extends ATNSimulator {
 		return configSet;
 	}
 
-	protected getReachableTarget(@NotNull source: ATNConfig, @NotNull trans: Transition, ttype: number): ATNState | undefined {
+	protected _getReachableTarget(@NotNull source: ATNConfig, @NotNull trans: Transition, ttype: number): ATNState | undefined {
 		if (trans.matches(ttype, 0, this.atn.maxTokenType)) {
 			return trans.target;
 		}
@@ -1513,28 +1513,28 @@ export class ParserATNSimulator extends ATNSimulator {
 	}
 
 	/** collect and set D's semantic context */
-	protected predicateDFAState(D: DFAState,
+	protected _predicateDFAState(D: DFAState,
 		configs: ATNConfigSet,
 		nalts: number): DFAState.PredPrediction[] | undefined {
-		let conflictingAlts: BitSet | undefined = this.getConflictingAltsFromConfigSet(configs);
+		let conflictingAlts: BitSet | undefined = this._getConflictingAltsFromConfigSet(configs);
 		if (!conflictingAlts) {
 			throw new Error("This unhandled scenario is intended to be unreachable, but I'm currently not sure of why we know that's the case.")
 		}
 
 		if (ParserATNSimulator.debug) console.log("predicateDFAState " + D);
-		let altToPred: SemanticContext[] | undefined = this.getPredsForAmbigAlts(conflictingAlts, configs, nalts);
+		let altToPred: SemanticContext[] | undefined = this._getPredsForAmbigAlts(conflictingAlts, configs, nalts);
 		// altToPred[uniqueAlt] is now our validating predicate (if any)
 		let predPredictions: DFAState.PredPrediction[] | undefined;
 		if (altToPred != null) {
 			// we have a validating predicate; test it
 			// Update DFA so reach becomes accept state with predicate
-			predPredictions = this.getPredicatePredictions(conflictingAlts, altToPred);
+			predPredictions = this._getPredicatePredictions(conflictingAlts, altToPred);
 			D.predicates = predPredictions;
 		}
 		return predPredictions;
 	}
 
-	protected getPredsForAmbigAlts(@NotNull ambigAlts: BitSet,
+	protected _getPredsForAmbigAlts(@NotNull ambigAlts: BitSet,
 		@NotNull configs: ATNConfigSet,
 		nalts: number): SemanticContext[] | undefined {
 		// REACH=[1|1|[]|0:0, 1|2|[]|0:1]
@@ -1577,7 +1577,7 @@ export class ParserATNSimulator extends ATNSimulator {
 		return result;
 	}
 
-	protected getPredicatePredictions(ambigAlts: BitSet | undefined, altToPred: SemanticContext[]): DFAState.PredPrediction[] | undefined {
+	protected _getPredicatePredictions(ambigAlts: BitSet | undefined, altToPred: SemanticContext[]): DFAState.PredPrediction[] | undefined {
 		let pairs: DFAState.PredPrediction[] = [];
 		let containsPredicate: boolean = false;
 		for (let i = 1; i < altToPred.length; i++) {
@@ -1612,7 +1612,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	 *  pairs that win. A {@code null} predicate indicates an alt containing an
 	 *  unpredicated config which behaves as "always true."
 	 */
-	protected evalSemanticContext(@NotNull predPredictions: DFAState.PredPrediction[],
+	protected _evalSemanticContext(@NotNull predPredictions: DFAState.PredPrediction[],
 		outerContext: ParserRuleContext,
 		complete: boolean): BitSet {
 		let predictions: BitSet = new BitSet();
@@ -1626,7 +1626,7 @@ export class ParserATNSimulator extends ATNSimulator {
 				continue;
 			}
 
-			let evaluatedResult: boolean = this.evalSemanticContextImpl(pair.pred, outerContext, pair.alt);
+			let evaluatedResult: boolean = this._evalSemanticContextImpl(pair.pred, outerContext, pair.alt);
 			if (ParserATNSimulator.debug || ParserATNSimulator.dfa_debug) {
 				console.log("eval pred " + pair + "=" + evaluatedResult);
 			}
@@ -1670,7 +1670,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	 *
 	 * @since 4.3
 	 */
-	protected evalSemanticContextImpl(@NotNull pred: SemanticContext, parserCallStack: ParserRuleContext, alt: number): boolean {
+	protected _evalSemanticContextImpl(@NotNull pred: SemanticContext, parserCallStack: ParserRuleContext, alt: number): boolean {
 		return pred.eval(this._parser, parserCallStack);
 	}
 
@@ -1681,7 +1681,7 @@ export class ParserATNSimulator extends ATNSimulator {
 		 ambig detection thought :(
 		  */
 
-	protected closure(sourceConfigs: ATNConfigSet,
+	protected _closure(sourceConfigs: ATNConfigSet,
 		@NotNull configs: ATNConfigSet,
 		collectPredicates: boolean,
 		hasMoreContext: boolean,
@@ -1696,14 +1696,14 @@ export class ParserATNSimulator extends ATNSimulator {
 		while (currentConfigs.size > 0) {
 			let intermediate: ATNConfigSet = new ATNConfigSet();
 			for (let config of asIterable(currentConfigs)) {
-				this.closureImpl(config, configs, intermediate, closureBusy, collectPredicates, hasMoreContext, contextCache, 0, treatEofAsEpsilon);
+				this._closureImpl(config, configs, intermediate, closureBusy, collectPredicates, hasMoreContext, contextCache, 0, treatEofAsEpsilon);
 			}
 
 			currentConfigs = intermediate;
 		}
 	}
 
-	protected closureImpl(@NotNull config: ATNConfig,
+	protected _closureImpl(@NotNull config: ATNConfig,
 		@NotNull configs: ATNConfigSet,
 		@Nullable intermediate: ATNConfigSet,
 		@NotNull closureBusy: Array2DHashSet<ATNConfig>,
@@ -1729,7 +1729,7 @@ export class ParserATNSimulator extends ATNSimulator {
 					c.outerContextDepth = config.outerContextDepth;
 					c.isPrecedenceFilterSuppressed = config.isPrecedenceFilterSuppressed;
 					assert(depth > MIN_INTEGER_VALUE);
-					this.closureImpl(c, configs, intermediate, closureBusy, collectPredicates, hasMoreContexts, contextCache, depth - 1, treatEofAsEpsilon);
+					this._closureImpl(c, configs, intermediate, closureBusy, collectPredicates, hasMoreContexts, contextCache, depth - 1, treatEofAsEpsilon);
 				}
 
 				if (!hasEmpty || !hasMoreContexts) {
@@ -1798,7 +1798,7 @@ export class ParserATNSimulator extends ATNSimulator {
 			let t: Transition = p.getOptimizedTransition(i);
 			let continueCollecting: boolean =
 				!(t instanceof ActionTransition) && collectPredicates;
-			let c: ATNConfig | undefined = this.getEpsilonTarget(config, t, continueCollecting, depth === 0, contextCache, treatEofAsEpsilon);
+			let c: ATNConfig | undefined = this._getEpsilonTarget(config, t, continueCollecting, depth === 0, contextCache, treatEofAsEpsilon);
 			if (c != null) {
 				if (t instanceof RuleTransition) {
 					if (intermediate != null && !collectPredicates) {
@@ -1859,7 +1859,7 @@ export class ParserATNSimulator extends ATNSimulator {
 					}
 				}
 
-				this.closureImpl(c, configs, intermediate, closureBusy, continueCollecting, hasMoreContexts, contextCache, newDepth, treatEofAsEpsilon);
+				this._closureImpl(c, configs, intermediate, closureBusy, continueCollecting, hasMoreContexts, contextCache, newDepth, treatEofAsEpsilon);
 			}
 		}
 	}
@@ -1870,19 +1870,19 @@ export class ParserATNSimulator extends ATNSimulator {
 		return "<rule " + index + ">";
 	}
 
-	protected getEpsilonTarget(@NotNull config: ATNConfig, @NotNull t: Transition, collectPredicates: boolean, inContext: boolean, contextCache: PredictionContextCache, treatEofAsEpsilon: boolean): ATNConfig | undefined {
+	protected _getEpsilonTarget(@NotNull config: ATNConfig, @NotNull t: Transition, collectPredicates: boolean, inContext: boolean, contextCache: PredictionContextCache, treatEofAsEpsilon: boolean): ATNConfig | undefined {
 		switch (t.serializationType) {
 		case TransitionType.RULE:
-			return this.ruleTransition(config, <RuleTransition>t, contextCache);
+			return this._ruleTransition(config, <RuleTransition>t, contextCache);
 
 		case TransitionType.PRECEDENCE:
-			return this.precedenceTransition(config, <PrecedencePredicateTransition>t, collectPredicates, inContext);
+			return this._precedenceTransition(config, <PrecedencePredicateTransition>t, collectPredicates, inContext);
 
 		case TransitionType.PREDICATE:
-			return this.predTransition(config, <PredicateTransition>t, collectPredicates, inContext);
+			return this._predTransition(config, <PredicateTransition>t, collectPredicates, inContext);
 
 		case TransitionType.ACTION:
-			return this.actionTransition(config, <ActionTransition>t);
+			return this._actionTransition(config, <ActionTransition>t);
 
 		case TransitionType.EPSILON:
 			return config.transform(t.target, false);
@@ -1906,13 +1906,13 @@ export class ParserATNSimulator extends ATNSimulator {
 	}
 
 	@NotNull
-	protected actionTransition(@NotNull config: ATNConfig, @NotNull t: ActionTransition): ATNConfig {
+	protected _actionTransition(@NotNull config: ATNConfig, @NotNull t: ActionTransition): ATNConfig {
 		if (ParserATNSimulator.debug) console.log("ACTION edge " + t.ruleIndex + ":" + t.actionIndex);
 		return config.transform(t.target, false);
 	}
 
 	@Nullable
-	protected precedenceTransition(@NotNull config: ATNConfig,
+	protected _precedenceTransition(@NotNull config: ATNConfig,
 		@NotNull pt: PrecedencePredicateTransition,
 		collectPredicates: boolean,
 		inContext: boolean): ATNConfig {
@@ -1940,7 +1940,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	}
 
 	@Nullable
-	protected predTransition(@NotNull config: ATNConfig,
+	protected _predTransition(@NotNull config: ATNConfig,
 		@NotNull pt: PredicateTransition,
 		collectPredicates: boolean,
 		inContext: boolean): ATNConfig {
@@ -1969,7 +1969,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	}
 
 	@NotNull
-	protected ruleTransition(@NotNull config: ATNConfig, @NotNull t: RuleTransition, @Nullable contextCache: PredictionContextCache): ATNConfig {
+	protected _ruleTransition(@NotNull config: ATNConfig, @NotNull t: RuleTransition, @Nullable contextCache: PredictionContextCache): ATNConfig {
 		if (ParserATNSimulator.debug) {
 			console.log("CALL rule " + this.getRuleName(t.target.ruleIndex) +
 				", ctx=" + config.context);
@@ -2162,7 +2162,7 @@ export class ParserATNSimulator extends ATNSimulator {
 		return new ConflictInfo(alts, exact);
 	}
 
-	protected getConflictingAltsFromConfigSet(configs: ATNConfigSet): BitSet | undefined {
+	protected _getConflictingAltsFromConfigSet(configs: ATNConfigSet): BitSet | undefined {
 		let conflictingAlts: BitSet | undefined = configs.conflictingAlts;
 		if (conflictingAlts == null && configs.uniqueAlt !== ATN.INVALID_ALT_NUMBER) {
 			conflictingAlts = new BitSet();
@@ -2215,7 +2215,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	}
 
 	@NotNull
-	protected noViableAlt(@NotNull input: TokenStream,
+	protected _noViableAlt(@NotNull input: TokenStream,
 		@NotNull outerContext: ParserRuleContext,
 		@NotNull configs: ATNConfigSet,
 		startIndex: number): NoViableAltException {
@@ -2225,7 +2225,7 @@ export class ParserATNSimulator extends ATNSimulator {
 			configs, outerContext);
 	}
 
-	protected getUniqueAlt(@NotNull configs: Collection<ATNConfig>): number {
+	protected _getUniqueAlt(@NotNull configs: Collection<ATNConfig>): number {
 		let alt: number = ATN.INVALID_ALT_NUMBER;
 		for (let c of asIterable(configs)) {
 			if (alt === ATN.INVALID_ALT_NUMBER) {
@@ -2238,7 +2238,7 @@ export class ParserATNSimulator extends ATNSimulator {
 		return alt;
 	}
 
-	protected configWithAltAtStopState(@NotNull configs: Collection<ATNConfig>, alt: number): boolean {
+	protected _configWithAltAtStopState(@NotNull configs: Collection<ATNConfig>, alt: number): boolean {
 		for (let c of asIterable(configs)) {
 			if (c.alt === alt) {
 				if (c.state instanceof RuleStopState) {
@@ -2250,7 +2250,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	}
 
 	@NotNull
-	protected addDFAEdge(@NotNull dfa: DFA,
+	protected _addDFAEdge(@NotNull dfa: DFA,
 		@NotNull fromState: DFAState,
 		t: number,
 		contextTransitions: IntegerList | undefined,
@@ -2259,7 +2259,7 @@ export class ParserATNSimulator extends ATNSimulator {
 		assert(contextTransitions == null || contextTransitions.isEmpty || dfa.isContextSensitive);
 
 		let from: DFAState = fromState;
-		let to: DFAState = this.addDFAState(dfa, toConfigs, contextCache);
+		let to: DFAState = this._addDFAState(dfa, toConfigs, contextCache);
 
 		if (contextTransitions != null) {
 			for (let context of contextTransitions.toArray()) {
@@ -2277,7 +2277,7 @@ export class ParserATNSimulator extends ATNSimulator {
 					continue;
 				}
 
-				next = this.addDFAContextState(dfa, from.configs, context, contextCache);
+				next = this._addDFAContextState(dfa, from.configs, context, contextCache);
 				assert(context !== PredictionContext.EMPTY_FULL_STATE_KEY || next.configs.isOutermostConfigSet);
 				from.setContextTarget(context, next);
 				from = next;
@@ -2285,12 +2285,12 @@ export class ParserATNSimulator extends ATNSimulator {
 		}
 
 		if (ParserATNSimulator.debug) console.log("EDGE " + from + " -> " + to + " upon " + this.getTokenName(t));
-		this.setDFAEdge(from, t, to);
+		this._setDFAEdge(from, t, to);
 		if (ParserATNSimulator.debug) console.log("DFA=\n" + dfa.toString(this._parser != null ? this._parser.vocabulary : VocabularyImpl.EMPTY_VOCABULARY, this._parser != null ? this._parser.ruleNames : undefined));
 		return to;
 	}
 
-	protected setDFAEdge(@Nullable p: DFAState, t: number, @Nullable q: DFAState): void {
+	protected _setDFAEdge(@Nullable p: DFAState, t: number, @Nullable q: DFAState): void {
 		if (p != null) {
 			p.setTarget(t, q);
 		}
@@ -2298,33 +2298,33 @@ export class ParserATNSimulator extends ATNSimulator {
 
 	/** See comment on LexerInterpreter.addDFAState. */
 	@NotNull
-	protected addDFAContextState(@NotNull dfa: DFA, @NotNull configs: ATNConfigSet, returnContext: number, contextCache: PredictionContextCache): DFAState {
+	protected _addDFAContextState(@NotNull dfa: DFA, @NotNull configs: ATNConfigSet, returnContext: number, contextCache: PredictionContextCache): DFAState {
 		if (returnContext !== PredictionContext.EMPTY_FULL_STATE_KEY) {
 			let contextConfigs: ATNConfigSet = new ATNConfigSet();
 			for (let config of asIterable(configs)) {
 				contextConfigs.add(config.appendContext(returnContext, contextCache));
 			}
 
-			return this.addDFAState(dfa, contextConfigs, contextCache);
+			return this._addDFAState(dfa, contextConfigs, contextCache);
 		}
 		else {
 			assert(!configs.isOutermostConfigSet, "Shouldn't be adding a duplicate edge.");
 			configs = configs.clone(true);
 			configs.isOutermostConfigSet = true;
-			return this.addDFAState(dfa, configs, contextCache);
+			return this._addDFAState(dfa, configs, contextCache);
 		}
 	}
 
 	/** See comment on LexerInterpreter.addDFAState. */
 	@NotNull
-	protected addDFAState(@NotNull dfa: DFA, @NotNull configs: ATNConfigSet, contextCache: PredictionContextCache): DFAState {
+	protected _addDFAState(@NotNull dfa: DFA, @NotNull configs: ATNConfigSet, contextCache: PredictionContextCache): DFAState {
 		let enableDfa: boolean = this.enable_global_context_dfa || !configs.isOutermostConfigSet;
 		if (enableDfa) {
 			if (!configs.isReadOnly) {
 				configs.optimizeConfigs(this);
 			}
 
-			let proposed: DFAState = this.createDFAState(dfa, configs);
+			let proposed: DFAState = this._createDFAState(dfa, configs);
 			let existing: DFAState | undefined = dfa.states.get(proposed);
 			if (existing != null) return existing;
 		}
@@ -2335,10 +2335,10 @@ export class ParserATNSimulator extends ATNSimulator {
 			}
 		}
 
-		let newState: DFAState = this.createDFAState(dfa, configs.clone(true));
+		let newState: DFAState = this._createDFAState(dfa, configs.clone(true));
 		// getDecisionState won't return undefined when we request a known valid decision
 		let decisionState: DecisionState = <DecisionState>this.atn.getDecisionState(dfa.decision);
-		let predictedAlt: number = this.getUniqueAlt(configs);
+		let predictedAlt: number = this._getUniqueAlt(configs);
 		if (predictedAlt !== ATN.INVALID_ALT_NUMBER) {
 			newState.acceptStateInfo = new AcceptStateInfo(predictedAlt);
 		} else if (configs.conflictingAlts != null) {
@@ -2349,7 +2349,7 @@ export class ParserATNSimulator extends ATNSimulator {
 		}
 
 		if (newState.isAcceptState && configs.hasSemanticContext) {
-			this.predicateDFAState(newState, configs, decisionState.numberOfTransitions);
+			this._predicateDFAState(newState, configs, decisionState.numberOfTransitions);
 		}
 
 		if (!enableDfa) {
@@ -2362,11 +2362,11 @@ export class ParserATNSimulator extends ATNSimulator {
 	}
 
 	@NotNull
-	protected createDFAState(@NotNull dfa: DFA, @NotNull configs: ATNConfigSet): DFAState {
+	protected _createDFAState(@NotNull dfa: DFA, @NotNull configs: ATNConfigSet): DFAState {
 		return new DFAState(configs);
 	}
 
-	protected reportAttemptingFullContext(@NotNull dfa: DFA, conflictingAlts: BitSet | undefined, @NotNull conflictState: SimulatorState, startIndex: number, stopIndex: number): void {
+	protected _reportAttemptingFullContext(@NotNull dfa: DFA, conflictingAlts: BitSet | undefined, @NotNull conflictState: SimulatorState, startIndex: number, stopIndex: number): void {
 		if (ParserATNSimulator.debug || ParserATNSimulator.retry_debug) {
 			let interval: Interval = Interval.of(startIndex, stopIndex);
 			console.log("reportAttemptingFullContext decision=" + dfa.decision + ":" + conflictState.s0.configs +
@@ -2380,7 +2380,7 @@ export class ParserATNSimulator extends ATNSimulator {
 		}
 	}
 
-	protected reportContextSensitivity(@NotNull dfa: DFA, prediction: number, @NotNull acceptState: SimulatorState, startIndex: number, stopIndex: number): void {
+	protected _reportContextSensitivity(@NotNull dfa: DFA, prediction: number, @NotNull acceptState: SimulatorState, startIndex: number, stopIndex: number): void {
 		if (ParserATNSimulator.debug || ParserATNSimulator.retry_debug) {
 			let interval: Interval = Interval.of(startIndex, stopIndex);
 			console.log("reportContextSensitivity decision=" + dfa.decision + ":" + acceptState.s0.configs +
@@ -2395,7 +2395,7 @@ export class ParserATNSimulator extends ATNSimulator {
 	}
 
 	/** If context sensitive parsing, we know it's ambiguity not conflict */
-	protected reportAmbiguity(@NotNull dfa: DFA,
+	protected _reportAmbiguity(@NotNull dfa: DFA,
 		D: DFAState,  // the DFA state from execATN(): void that had SLL conflicts
 		startIndex: number,
 		stopIndex: number,
@@ -2417,7 +2417,7 @@ export class ParserATNSimulator extends ATNSimulator {
 		}
 	}
 
-	protected getReturnState(context: RuleContext): number {
+	protected _getReturnState(context: RuleContext): number {
 		if (context.isEmpty) {
 			return PredictionContext.EMPTY_FULL_STATE_KEY;
 		}
@@ -2427,7 +2427,7 @@ export class ParserATNSimulator extends ATNSimulator {
 		return transition.followState.stateNumber;
 	}
 
-	protected skipTailCalls(context: ParserRuleContext): ParserRuleContext {
+	protected _skipTailCalls(context: ParserRuleContext): ParserRuleContext {
 		if (!this.optimize_tail_calls) {
 			return context;
 		}

--- a/src/atn/PredictionContext.ts
+++ b/src/atn/PredictionContext.ts
@@ -52,13 +52,13 @@ export abstract class PredictionContext implements Equatable {
 		this._cachedHashCode = cachedHashCode;
 	}
 
-	protected static calculateEmptyHashCode(): number {
+	protected static _calculateEmptyHashCode(): number {
 		let hash: number = MurmurHash.initialize(INITIAL_HASH);
 		hash = MurmurHash.finish(hash, 0);
 		return hash;
 	}
 
-	protected static calculateSingleHashCode(parent: PredictionContext, returnState: number): number {
+	protected static _calculateSingleHashCode(parent: PredictionContext, returnState: number): number {
 		let hash: number = MurmurHash.initialize(INITIAL_HASH);
 		hash = MurmurHash.update(hash, parent);
 		hash = MurmurHash.update(hash, returnState);
@@ -66,7 +66,7 @@ export abstract class PredictionContext implements Equatable {
 		return hash;
 	}
 
-	protected static calculateHashCode(parents: PredictionContext[], returnStates: number[]): number {
+	protected static _calculateHashCode(parents: PredictionContext[], returnStates: number[]): number {
 		let hash: number = MurmurHash.initialize(INITIAL_HASH);
 
 		for (let parent of parents) {
@@ -90,9 +90,9 @@ export abstract class PredictionContext implements Equatable {
 	// @NotNull
 	abstract getParent(index: number): PredictionContext;
 
-	protected abstract addEmptyContext(): PredictionContext;
+	protected abstract _addEmptyContext(): PredictionContext;
 
-	protected abstract removeEmptyContext(): PredictionContext;
+	protected abstract _removeEmptyContext(): PredictionContext;
 
 	static fromRuleContext(atn: ATN, outerContext: RuleContext, fullContext: boolean = true): PredictionContext {
 		if (outerContext.isEmpty) {
@@ -112,11 +112,11 @@ export abstract class PredictionContext implements Equatable {
 	}
 
 	private static _addEmptyContext(context: PredictionContext): PredictionContext {
-		return context.addEmptyContext();
+		return context._addEmptyContext();
 	}
 
 	private static _removeEmptyContext(context: PredictionContext): PredictionContext {
-		return context.removeEmptyContext();
+		return context._removeEmptyContext();
 	}
 
 	static join(@NotNull context0: PredictionContext, @NotNull context1: PredictionContext, @NotNull contextCache: PredictionContextCache = PredictionContextCache.UNCACHED): PredictionContext {
@@ -370,7 +370,7 @@ class EmptyPredictionContext extends PredictionContext {
 	private _fullContext: boolean;
 
 	constructor(fullContext: boolean) {
-		super(PredictionContext.calculateEmptyHashCode());
+		super(PredictionContext._calculateEmptyHashCode());
 		this._fullContext = fullContext;
 	}
 
@@ -379,12 +379,12 @@ class EmptyPredictionContext extends PredictionContext {
 	}
 
 	@Override
-	protected addEmptyContext(): PredictionContext {
+	protected _addEmptyContext(): PredictionContext {
 		return this;
 	}
 
 	@Override
-	protected removeEmptyContext(): PredictionContext {
+	protected _removeEmptyContext(): PredictionContext {
 		throw new Error("Cannot remove the empty context from itself.");
 	}
 
@@ -448,7 +448,7 @@ class ArrayPredictionContext extends PredictionContext {
 	returnStates: number[];
 
 	constructor( @NotNull parents: PredictionContext[], returnStates: number[], hashCode?: number) {
-		super(hashCode || PredictionContext.calculateHashCode(parents, returnStates));
+		super(hashCode || PredictionContext._calculateHashCode(parents, returnStates));
 		assert(parents.length === returnStates.length);
 		assert(returnStates.length > 1 || returnStates[0] !== PredictionContext.EMPTY_FULL_STATE_KEY, "Should be using PredictionContext.EMPTY instead.");
 
@@ -487,7 +487,7 @@ class ArrayPredictionContext extends PredictionContext {
 	}
 
 	@Override
-	protected addEmptyContext(): PredictionContext {
+	protected _addEmptyContext(): PredictionContext {
 		if (this.hasEmpty) {
 			return this;
 		}
@@ -500,7 +500,7 @@ class ArrayPredictionContext extends PredictionContext {
 	}
 
 	@Override
-	protected removeEmptyContext(): PredictionContext {
+	protected _removeEmptyContext(): PredictionContext {
 		if (!this.hasEmpty) {
 			return this;
 		}
@@ -651,7 +651,7 @@ export class SingletonPredictionContext extends PredictionContext {
 	returnState: number;
 
 	constructor(@NotNull parent: PredictionContext, returnState: number) {
-		super(PredictionContext.calculateSingleHashCode(parent, returnState));
+		super(PredictionContext._calculateSingleHashCode(parent, returnState));
 		// assert(returnState != PredictionContext.EMPTY_FULL_STATE_KEY && returnState != PredictionContext.EMPTY_LOCAL_STATE_KEY);
 		this.parent = parent;
 		this.returnState = returnState;
@@ -695,14 +695,14 @@ export class SingletonPredictionContext extends PredictionContext {
 	}
 
 	@Override
-	protected addEmptyContext(): PredictionContext {
+	protected _addEmptyContext(): PredictionContext {
 		let parents: PredictionContext[] = [this.parent, PredictionContext.EMPTY_FULL];
 		let returnStates: number[] = [this.returnState, PredictionContext.EMPTY_FULL_STATE_KEY];
 		return new ArrayPredictionContext(parents, returnStates);
 	}
 
 	@Override
-	protected removeEmptyContext(): PredictionContext {
+	protected _removeEmptyContext(): PredictionContext {
 		return this;
 	}
 

--- a/src/atn/PredictionContext.ts
+++ b/src/atn/PredictionContext.ts
@@ -46,10 +46,10 @@ export abstract class PredictionContext implements Equatable {
 	 *  }
 	 * </pre>
 	 */
-	private readonly cachedHashCode: number;
+	private readonly _cachedHashCode: number;
 
 	constructor(cachedHashCode: number) {
-		this.cachedHashCode = cachedHashCode;
+		this._cachedHashCode = cachedHashCode;
 	}
 
 	protected static calculateEmptyHashCode(): number {
@@ -111,11 +111,11 @@ export abstract class PredictionContext implements Equatable {
 		return parent.getChild(transition.followState.stateNumber);
 	}
 
-	private static addEmptyContext(context: PredictionContext): PredictionContext {
+	private static _addEmptyContext(context: PredictionContext): PredictionContext {
 		return context.addEmptyContext();
 	}
 
-	private static removeEmptyContext(context: PredictionContext): PredictionContext {
+	private static _removeEmptyContext(context: PredictionContext): PredictionContext {
 		return context.removeEmptyContext();
 	}
 
@@ -125,9 +125,9 @@ export abstract class PredictionContext implements Equatable {
 		}
 
 		if (context0.isEmpty) {
-			return PredictionContext.isEmptyLocal(context0) ? context0 : PredictionContext.addEmptyContext(context1);
+			return PredictionContext.isEmptyLocal(context0) ? context0 : PredictionContext._addEmptyContext(context1);
 		} else if (context1.isEmpty) {
-			return PredictionContext.isEmptyLocal(context1) ? context1 : PredictionContext.addEmptyContext(context0);
+			return PredictionContext.isEmptyLocal(context1) ? context1 : PredictionContext._addEmptyContext(context0);
 		}
 
 		let context0size: number = context0.size;
@@ -294,7 +294,7 @@ export abstract class PredictionContext implements Equatable {
 
 	@Override
 	hashCode(): number {
-		return this.cachedHashCode;
+		return this._cachedHashCode;
 	}
 
 	// @Override
@@ -367,15 +367,15 @@ export abstract class PredictionContext implements Equatable {
 }
 
 class EmptyPredictionContext extends PredictionContext {
-	private fullContext: boolean;
+	private _fullContext: boolean;
 
 	constructor(fullContext: boolean) {
 		super(PredictionContext.calculateEmptyHashCode());
-		this.fullContext = fullContext;
+		this._fullContext = fullContext;
 	}
 
 	get isFullContext(): boolean {
-		return this.fullContext;
+		return this._fullContext;
 	}
 
 	@Override
@@ -516,10 +516,10 @@ class ArrayPredictionContext extends PredictionContext {
 
 	@Override
 	appendContext(suffix: PredictionContext, contextCache: PredictionContextCache): PredictionContext {
-		return ArrayPredictionContext.appendContextImpl(this, suffix, new PredictionContext.IdentityHashMap());
+		return ArrayPredictionContext._appendContextImpl(this, suffix, new PredictionContext.IdentityHashMap());
 	}
 
-	private static appendContextImpl(context: PredictionContext, suffix: PredictionContext, visited: PredictionContext.IdentityHashMap): PredictionContext {
+	private static _appendContextImpl(context: PredictionContext, suffix: PredictionContext, visited: PredictionContext.IdentityHashMap): PredictionContext {
 		if (suffix.isEmpty) {
 			if (PredictionContext.isEmptyLocal(suffix)) {
 				if (context.hasEmpty) {
@@ -553,7 +553,7 @@ class ArrayPredictionContext extends PredictionContext {
 				}
 
 				for (let i = 0; i < parentCount; i++) {
-					updatedParents[i] = ArrayPredictionContext.appendContextImpl(context.getParent(i), suffix, visited);
+					updatedParents[i] = ArrayPredictionContext._appendContextImpl(context.getParent(i), suffix, visited);
 				}
 
 				if (updatedParents.length === 1) {
@@ -588,10 +588,10 @@ class ArrayPredictionContext extends PredictionContext {
 		}
 
 		let other: ArrayPredictionContext = o;
-		return this.equalsImpl(other, new Array2DHashSet<PredictionContextCache.IdentityCommutativePredictionContextOperands>());
+		return this._equalsImpl(other, new Array2DHashSet<PredictionContextCache.IdentityCommutativePredictionContextOperands>());
 	}
 
-	private equalsImpl(other: ArrayPredictionContext, visited: JavaSet<PredictionContextCache.IdentityCommutativePredictionContextOperands>): boolean {
+	private _equalsImpl(other: ArrayPredictionContext, visited: JavaSet<PredictionContextCache.IdentityCommutativePredictionContextOperands>): boolean {
 		let selfWorkList: PredictionContext[] = [];
 		let otherWorkList: PredictionContext[] = [];
 		selfWorkList.push(this);

--- a/src/atn/PredictionContext.ts
+++ b/src/atn/PredictionContext.ts
@@ -385,17 +385,17 @@ class EmptyPredictionContext extends PredictionContext {
 
 	@Override
 	protected removeEmptyContext(): PredictionContext {
-		throw "Cannot remove the empty context from itself.";
+		throw new Error("Cannot remove the empty context from itself.");
 	}
 
 	@Override
 	getParent(index: number): PredictionContext {
-		throw "index out of bounds";
+		throw new Error("index out of bounds");
 	}
 
 	@Override
 	getReturnState(index: number): number {
-		throw "index out of bounds";
+		throw new Error("index out of bounds");
 	}
 
 	@Override
@@ -526,14 +526,14 @@ class ArrayPredictionContext extends PredictionContext {
 					return PredictionContext.EMPTY_LOCAL;
 				}
 
-				throw "what to do here?";
+				throw new Error("what to do here?");
 			}
 
 			return context;
 		}
 
 		if (suffix.size !== 1) {
-			throw "Appending a tree suffix is not yet supported.";
+			throw new Error("Appending a tree suffix is not yet supported.");
 		}
 
 		let result = visited.get(context);

--- a/src/atn/PredictionContextCache.ts
+++ b/src/atn/PredictionContextCache.ts
@@ -21,75 +21,75 @@ import * as assert from 'assert';
 export class PredictionContextCache {
 	static UNCACHED: PredictionContextCache = new PredictionContextCache(false);
 
-	private contexts: JavaMap<PredictionContext, PredictionContext> =
+	private _contexts: JavaMap<PredictionContext, PredictionContext> =
 		new Array2DHashMap<PredictionContext, PredictionContext>(ObjectEqualityComparator.INSTANCE);
-	private childContexts: JavaMap<PredictionContextCache.PredictionContextAndInt, PredictionContext> =
+	private _childContexts: JavaMap<PredictionContextCache.PredictionContextAndInt, PredictionContext> =
 		new Array2DHashMap<PredictionContextCache.PredictionContextAndInt, PredictionContext>(ObjectEqualityComparator.INSTANCE);
-	private joinContexts: JavaMap<PredictionContextCache.IdentityCommutativePredictionContextOperands, PredictionContext> =
+	private _joinContexts: JavaMap<PredictionContextCache.IdentityCommutativePredictionContextOperands, PredictionContext> =
 		new Array2DHashMap<PredictionContextCache.IdentityCommutativePredictionContextOperands, PredictionContext>(ObjectEqualityComparator.INSTANCE);
 
-	private enableCache: boolean;
+	private _enableCache: boolean;
 
 	constructor(enableCache: boolean = true) {
-		this.enableCache = enableCache;
+		this._enableCache = enableCache;
 	}
 
 	getAsCached(context: PredictionContext): PredictionContext {
-		if (!this.enableCache) {
+		if (!this._enableCache) {
 			return context;
 		}
 
-		let result = this.contexts.get(context);
+		let result = this._contexts.get(context);
 		if (!result) {
 			result = context;
-			this.contexts.put(context, context);
+			this._contexts.put(context, context);
 		}
 
 		return result;
 	}
 
 	getChild(context: PredictionContext, invokingState: number): PredictionContext {
-		if (!this.enableCache) {
+		if (!this._enableCache) {
 			return context.getChild(invokingState);
 		}
 
 		let operands: PredictionContextCache.PredictionContextAndInt = new PredictionContextCache.PredictionContextAndInt(context, invokingState);
-		let result = this.childContexts.get(operands);
+		let result = this._childContexts.get(operands);
 		if (!result) {
 			result = context.getChild(invokingState);
 			result = this.getAsCached(result);
-			this.childContexts.put(operands, result);
+			this._childContexts.put(operands, result);
 		}
 
 		return result;
 	}
 
 	join(x: PredictionContext, y: PredictionContext): PredictionContext {
-		if (!this.enableCache) {
+		if (!this._enableCache) {
 			return PredictionContext.join(x, y, this);
 		}
 
 		let operands: PredictionContextCache.IdentityCommutativePredictionContextOperands = new PredictionContextCache.IdentityCommutativePredictionContextOperands(x, y);
-		let result = this.joinContexts.get(operands);
+		let result = this._joinContexts.get(operands);
 		if (result) {
 			return result;
 		}
 
 		result = PredictionContext.join(x, y, this);
 		result = this.getAsCached(result);
-		this.joinContexts.put(operands, result);
+		this._joinContexts.put(operands, result);
 		return result;
 	}
 }
 
 export namespace PredictionContextCache {
 	export class PredictionContextAndInt {
-		private obj: PredictionContext;
-		private value: number;
+		private _obj: PredictionContext;
+		private _value: number;
 
 		constructor(obj: PredictionContext, value: number) {
-			this.obj = obj;
-			this.value = value;
+			this._obj = obj;
+			this._value = value;
 		}
 
 		@Override
@@ -101,15 +101,15 @@ export namespace PredictionContextCache {
 			}
 
 			let other: PredictionContextAndInt = obj;
-			return this.value === other.value
-				&& (this.obj === other.obj || (this.obj != null && this.obj.equals(other.obj)));
+			return this._value === other._value
+				&& (this._obj === other._obj || (this._obj != null && this._obj.equals(other._obj)));
 		}
 
 		@Override
 		hashCode(): number {
 			let hashCode: number = 5;
-			hashCode = 7 * hashCode + (this.obj != null ? this.obj.hashCode() : 0);
-			hashCode = 7 * hashCode + this.value;
+			hashCode = 7 * hashCode + (this._obj != null ? this._obj.hashCode() : 0);
+			hashCode = 7 * hashCode + this._value;
 			return hashCode;
 		}
 	}

--- a/src/atn/Transition.ts
+++ b/src/atn/Transition.ts
@@ -58,7 +58,7 @@ export abstract class Transition {
 
 	constructor(@NotNull target: ATNState) {
 		if (target == null) {
-			throw "target cannot be null.";
+			throw new Error("target cannot be null.");
 		}
 
 		this.target = target;

--- a/src/dfa/DFA.ts
+++ b/src/dfa/DFA.ts
@@ -49,13 +49,13 @@ export class DFA {
 	@NotNull
 	atn: ATN;
 
-	private nextStateNumber: number = 0;
+	private _nextStateNumber: number = 0;
 
 	/**
 	 * {@code true} if this DFA is for a precedence decision; otherwise,
 	 * {@code false}. This is the backing field for {@link #isPrecedenceDfa}.
 	 */
-	private precedenceDfa: boolean;
+	private _precedenceDfa: boolean;
 
 	/**
 	 * Constructs a `DFA` instance associated with a lexer mode.
@@ -96,7 +96,7 @@ export class DFA {
 			}
 		}
 
-		this.precedenceDfa = isPrecedenceDfa;
+		this._precedenceDfa = isPrecedenceDfa;
 	}
 
 	/**
@@ -111,7 +111,7 @@ export class DFA {
 	 * @see Parser.precedence
 	 */
 	get isPrecedenceDfa(): boolean {
-		return this.precedenceDfa;
+		return this._precedenceDfa;
 	}
 
 	/**
@@ -186,7 +186,7 @@ export class DFA {
 	}
 
 	addState(state: DFAState): DFAState {
-		state.stateNumber = this.nextStateNumber++;
+		state.stateNumber = this._nextStateNumber++;
 		return this.states.getOrAdd(state);
 	}
 

--- a/src/dfa/DFASerializer.ts
+++ b/src/dfa/DFASerializer.ts
@@ -70,7 +70,7 @@ export class DFASerializer {
 					}
 
 					let contextSymbol: boolean = false;
-					buf += (this.getStateString(s)) + ("-") + (this.getEdgeLabel(entry)) + ("->");
+					buf += (this.getStateString(s)) + ("-") + (this._getEdgeLabel(entry)) + ("->");
 					if (s.isContextSymbol(entry)) {
 						buf += ("!");
 						contextSymbol = true;
@@ -89,7 +89,7 @@ export class DFASerializer {
 					for (let entry of contextEdgeKeys) {
 						buf += (this.getStateString(s))
 							+ ("-")
-							+ (this.getContextLabel(entry))
+							+ (this._getContextLabel(entry))
 							+ ("->")
 							+ (this.getStateString(contextEdges.get(entry)!))
 							+ ("\n");
@@ -103,7 +103,7 @@ export class DFASerializer {
 		return output;
 	}
 
-	protected getContextLabel(i: number): string {
+	protected _getContextLabel(i: number): string {
 		if (i === PredictionContext.EMPTY_FULL_STATE_KEY) {
 			return "ctx:EMPTY_FULL";
 		}
@@ -122,7 +122,7 @@ export class DFASerializer {
 		return "ctx:" + String(i);
 	}
 
-	protected getEdgeLabel(i: number): string {
+	protected _getEdgeLabel(i: number): string {
 		return this._vocabulary.getDisplayName(i);
 	}
 

--- a/src/dfa/DFASerializer.ts
+++ b/src/dfa/DFASerializer.ts
@@ -20,9 +20,9 @@ import { VocabularyImpl } from '../VocabularyImpl';
 /** A DFA walker that knows how to dump them to serialized strings. */
 export class DFASerializer {
 	@NotNull
-	private dfa: DFA;
+	private _dfa: DFA;
 	@NotNull
-	private vocabulary: Vocabulary;
+	private _vocabulary: Vocabulary;
 
 	ruleNames?: string[];
 
@@ -40,22 +40,22 @@ export class DFASerializer {
 			vocabulary = VocabularyImpl.EMPTY_VOCABULARY;
 		}
 
-		this.dfa = dfa;
-		this.vocabulary = vocabulary;
+		this._dfa = dfa;
+		this._vocabulary = vocabulary;
 		this.ruleNames = ruleNames;
 		this.atn = atn;
 	}
 
 	@Override
 	toString(): string {
-		if (!this.dfa.s0) {
+		if (!this._dfa.s0) {
 			return "";
 		}
 
 		let buf = "";
 
-		if (this.dfa.states) {
-			let states: DFAState[] = new Array<DFAState>(...this.dfa.states.toArray());
+		if (this._dfa.states) {
+			let states: DFAState[] = new Array<DFAState>(...this._dfa.states.toArray());
 			states.sort((o1, o2) => o1.stateNumber - o2.stateNumber);
 
 			for (let s of states) {
@@ -123,7 +123,7 @@ export class DFASerializer {
 	}
 
 	protected getEdgeLabel(i: number): string {
-		return this.vocabulary.getDisplayName(i);
+		return this._vocabulary.getDisplayName(i);
 	}
 
 	getStateString(s: DFAState): string {

--- a/src/dfa/DFAState.ts
+++ b/src/dfa/DFAState.ts
@@ -56,10 +56,10 @@ export class DFAState {
 
 	/** These keys for these edges are the top level element of the global context. */
 	@NotNull
-	private readonly contextEdges: Map<number, DFAState>;
+	private readonly _contextEdges: Map<number, DFAState>;
 
 	/** Symbols in this set require a global context transition before matching an input symbol. */
-	private contextSymbols: BitSet | undefined;
+	private _contextSymbols: BitSet | undefined;
 
 	/**
 	 * This list is computed by {@link ParserATNSimulator#predicateDFAState}.
@@ -74,11 +74,11 @@ export class DFAState {
 	constructor(configs: ATNConfigSet) {
 		this.configs = configs;
 		this.edges = new Map<number, DFAState>();
-		this.contextEdges = new Map<number, DFAState>();
+		this._contextEdges = new Map<number, DFAState>();
 	}
 
 	get isContextSensitive(): boolean {
-		return !!this.contextSymbols;
+		return !!this._contextSymbols;
 	}
 
 	isContextSymbol(symbol: number): boolean {
@@ -86,12 +86,12 @@ export class DFAState {
 			return false;
 		}
 
-		return this.contextSymbols!.get(symbol);
+		return this._contextSymbols!.get(symbol);
 	}
 
 	setContextSymbol(symbol: number): void {
 		assert(this.isContextSensitive);
-		this.contextSymbols!.set(symbol);
+		this._contextSymbols!.set(symbol);
 	}
 
 	setContextSensitive(atn: ATN): void {
@@ -100,8 +100,8 @@ export class DFAState {
 			return;
 		}
 
-		if (!this.contextSymbols) {
-			this.contextSymbols = new BitSet();
+		if (!this._contextSymbols) {
+			this._contextSymbols = new BitSet();
 		}
 	}
 
@@ -150,7 +150,7 @@ export class DFAState {
 			invokingState = -1;
 		}
 
-		return this.contextEdges.get(invokingState);
+		return this._contextEdges.get(invokingState);
 	}
 
 	setContextTarget(invokingState: number, target: DFAState): void {
@@ -162,11 +162,11 @@ export class DFAState {
 			invokingState = -1;
 		}
 
-		this.contextEdges.set(invokingState, target);
+		this._contextEdges.set(invokingState, target);
 	}
 
 	getContextEdgeMap(): Map<number, DFAState> {
-		let map = new Map<number, DFAState>(this.contextEdges);
+		let map = new Map<number, DFAState>(this._contextEdges);
 		let existing = map.get(-1);
 		if (existing !== undefined) {
 			if (map.size === 1) {

--- a/src/dfa/LexerDFASerializer.ts
+++ b/src/dfa/LexerDFASerializer.ts
@@ -17,7 +17,7 @@ export class LexerDFASerializer extends DFASerializer {
 
 	@Override
 	@NotNull
-	protected getEdgeLabel(i: number): string {
+	protected _getEdgeLabel(i: number): string {
 		return "'" + String.fromCharCode(i) + "'";
 	}
 }

--- a/src/misc/Array2DHashMap.ts
+++ b/src/misc/Array2DHashMap.ts
@@ -16,40 +16,40 @@ import { JavaIterator } from './Stubs';
 type Bucket<K, V> = { key: K, value?: V };
 
 class MapKeyEqualityComparator<K, V> implements EqualityComparator<Bucket<K, V>> {
-	private readonly keyComparator: EqualityComparator<K>;
+	private readonly _keyComparator: EqualityComparator<K>;
 
 	constructor(keyComparator: EqualityComparator<K>) {
-		this.keyComparator = keyComparator;
+		this._keyComparator = keyComparator;
 	}
 
 	hashCode(obj: Bucket<K, V>): number {
-		return this.keyComparator.hashCode(obj.key);
+		return this._keyComparator.hashCode(obj.key);
 	}
 
 	equals(a: Bucket<K, V>, b: Bucket<K, V>): boolean {
-		return this.keyComparator.equals(a.key, b.key);
+		return this._keyComparator.equals(a.key, b.key);
 	}
 }
 
 export class Array2DHashMap<K, V> implements JavaMap<K, V> {
-	private backingStore: Array2DHashSet<Bucket<K, V>>;
+	private _backingStore: Array2DHashSet<Bucket<K, V>>;
 
 	constructor(keyComparer: EqualityComparator<K>);
 	constructor(map: Array2DHashMap<K, V>);
 	constructor(keyComparer: EqualityComparator<K> | Array2DHashMap<K, V>) {
 		if (keyComparer instanceof Array2DHashMap) {
-			this.backingStore = new Array2DHashSet<Bucket<K, V>>(keyComparer.backingStore);
+			this._backingStore = new Array2DHashSet<Bucket<K, V>>(keyComparer._backingStore);
 		} else {
-			this.backingStore = new Array2DHashSet<Bucket<K, V>>(new MapKeyEqualityComparator<K, V>(keyComparer));
+			this._backingStore = new Array2DHashSet<Bucket<K, V>>(new MapKeyEqualityComparator<K, V>(keyComparer));
 		}
 	}
 
 	clear(): void {
-		this.backingStore.clear();
+		this._backingStore.clear();
 	}
 
 	containsKey(key: K): boolean {
-		return this.backingStore.contains({ key });
+		return this._backingStore.contains({ key });
 	}
 
 	containsValue(value: V): boolean {
@@ -57,11 +57,11 @@ export class Array2DHashMap<K, V> implements JavaMap<K, V> {
 	}
 
 	entrySet(): JavaSet<JavaMap.Entry<K, V>> {
-		return new EntrySet<K, V>(this, this.backingStore);
+		return new EntrySet<K, V>(this, this._backingStore);
 	}
 
 	get(key: K): V | undefined {
-		let bucket = this.backingStore.get({ key });
+		let bucket = this._backingStore.get({ key });
 		if (!bucket) {
 			return undefined;
 		}
@@ -70,18 +70,18 @@ export class Array2DHashMap<K, V> implements JavaMap<K, V> {
 	}
 
 	get isEmpty(): boolean {
-		return this.backingStore.isEmpty;
+		return this._backingStore.isEmpty;
 	}
 
 	keySet(): JavaSet<K> {
-		return new KeySet<K, V>(this, this.backingStore);
+		return new KeySet<K, V>(this, this._backingStore);
 	}
 
 	put(key: K, value: V): V | undefined {
-		let element = this.backingStore.get({ key, value });
+		let element = this._backingStore.get({ key, value });
 		let result: V | undefined;
 		if (!element) {
-			this.backingStore.add({ key, value });
+			this._backingStore.add({ key, value });
 		} else {
 			result = element.value;
 			element.value = value;
@@ -91,10 +91,10 @@ export class Array2DHashMap<K, V> implements JavaMap<K, V> {
 	}
 
 	putIfAbsent(key: K, value: V): V | undefined {
-		let element = this.backingStore.get({ key, value });
+		let element = this._backingStore.get({ key, value });
 		let result: V | undefined;
 		if (!element) {
-			this.backingStore.add({ key, value });
+			this._backingStore.add({ key, value });
 		} else {
 			result = element.value;
 		}
@@ -110,20 +110,20 @@ export class Array2DHashMap<K, V> implements JavaMap<K, V> {
 
 	remove(key: K): V | undefined {
 		let value = this.get(key);
-		this.backingStore.remove({ key });
+		this._backingStore.remove({ key });
 		return value;
 	}
 
 	get size(): number {
-		return this.backingStore.size;
+		return this._backingStore.size;
 	}
 
 	values(): JavaCollection<V> {
-		return new ValueCollection<K, V>(this, this.backingStore);
+		return new ValueCollection<K, V>(this, this._backingStore);
 	}
 
 	hashCode(): number {
-		return this.backingStore.hashCode();
+		return this._backingStore.hashCode();
 	}
 
 	equals(o: any): boolean {
@@ -131,17 +131,17 @@ export class Array2DHashMap<K, V> implements JavaMap<K, V> {
 			return false;
 		}
 
-		return this.backingStore.equals(o.backingStore);
+		return this._backingStore.equals(o._backingStore);
 	}
 }
 
 class EntrySet<K, V> implements JavaSet<JavaMap.Entry<K, V>> {
-	private readonly map: Array2DHashMap<K, V>;
-	private readonly backingStore: Array2DHashSet<Bucket<K, V>>;
+	private readonly _map: Array2DHashMap<K, V>;
+	private readonly _backingStore: Array2DHashSet<Bucket<K, V>>;
 
 	constructor(map: Array2DHashMap<K, V>, backingStore: Array2DHashSet<Bucket<K, V>>) {
-		this.map = map;
-		this.backingStore = backingStore;
+		this._map = map;
+		this._backingStore = backingStore;
 	}
 
 	add(e: JavaMap.Entry<K, V>): boolean {
@@ -153,7 +153,7 @@ class EntrySet<K, V> implements JavaSet<JavaMap.Entry<K, V>> {
 	}
 
 	clear(): void {
-		this.map.clear();
+		this._map.clear();
 	}
 
 	contains(o: any): boolean {
@@ -177,15 +177,15 @@ class EntrySet<K, V> implements JavaSet<JavaMap.Entry<K, V>> {
 			return false;
 		}
 
-		return this.backingStore.equals(o.backingStore);
+		return this._backingStore.equals(o._backingStore);
 	}
 
 	hashCode(): number {
-		return this.backingStore.hashCode();
+		return this._backingStore.hashCode();
 	}
 
 	get isEmpty(): boolean {
-		return this.backingStore.isEmpty;
+		return this._backingStore.isEmpty;
 	}
 
 	iterator(): JavaIterator<JavaMap.Entry<K, V>> {
@@ -210,7 +210,7 @@ class EntrySet<K, V> implements JavaSet<JavaMap.Entry<K, V>> {
 	}
 
 	get size(): number {
-		return this.backingStore.size;
+		return this._backingStore.size;
 	}
 
 	toArray(): JavaMap.Entry<K, V>[];
@@ -221,12 +221,12 @@ class EntrySet<K, V> implements JavaSet<JavaMap.Entry<K, V>> {
 }
 
 class KeySet<K, V> implements JavaSet<K> {
-	private readonly map: Array2DHashMap<K, V>;
-	private readonly backingStore: Array2DHashSet<Bucket<K, V>>;
+	private readonly _map: Array2DHashMap<K, V>;
+	private readonly _backingStore: Array2DHashSet<Bucket<K, V>>;
 
 	constructor(map: Array2DHashMap<K, V>, backingStore: Array2DHashSet<Bucket<K, V>>) {
-		this.map = map;
-		this.backingStore = backingStore;
+		this._map = map;
+		this._backingStore = backingStore;
 	}
 
 	add(e: K): boolean {
@@ -238,11 +238,11 @@ class KeySet<K, V> implements JavaSet<K> {
 	}
 
 	clear(): void {
-		this.map.clear();
+		this._map.clear();
 	}
 
 	contains(o: any): boolean {
-		return this.backingStore.contains({ key: o });
+		return this._backingStore.contains({ key: o });
 	}
 
 	containsAll(collection: Collection<any>): boolean {
@@ -262,15 +262,15 @@ class KeySet<K, V> implements JavaSet<K> {
 			return false;
 		}
 
-		return this.backingStore.equals(o.backingStore);
+		return this._backingStore.equals(o._backingStore);
 	}
 
 	hashCode(): number {
-		return this.backingStore.hashCode();
+		return this._backingStore.hashCode();
 	}
 
 	get isEmpty(): boolean {
-		return this.backingStore.isEmpty;
+		return this._backingStore.isEmpty;
 	}
 
 	iterator(): JavaIterator<K> {
@@ -278,7 +278,7 @@ class KeySet<K, V> implements JavaSet<K> {
 	}
 
 	remove(o: any): boolean {
-		return this.backingStore.remove({ key: o });
+		return this._backingStore.remove({ key: o });
 	}
 
 	removeAll(collection: Collection<any>): boolean {
@@ -295,7 +295,7 @@ class KeySet<K, V> implements JavaSet<K> {
 	}
 
 	get size(): number {
-		return this.backingStore.size;
+		return this._backingStore.size;
 	}
 
 	toArray(): K[];
@@ -306,12 +306,12 @@ class KeySet<K, V> implements JavaSet<K> {
 }
 
 class ValueCollection<K, V> implements JavaCollection<V> {
-	private readonly map: Array2DHashMap<K, V>;
-	private readonly backingStore: Array2DHashSet<Bucket<K, V>>;
+	private readonly _map: Array2DHashMap<K, V>;
+	private readonly _backingStore: Array2DHashSet<Bucket<K, V>>;
 
 	constructor(map: Array2DHashMap<K, V>, backingStore: Array2DHashSet<Bucket<K, V>>) {
-		this.map = map;
-		this.backingStore = backingStore;
+		this._map = map;
+		this._backingStore = backingStore;
 	}
 
 	add(e: V): boolean {
@@ -323,11 +323,11 @@ class ValueCollection<K, V> implements JavaCollection<V> {
 	}
 
 	clear(): void {
-		this.map.clear();
+		this._map.clear();
 	}
 
 	contains(o: any): boolean {
-		for (let bucket of asIterable<Bucket<K, V>>(this.backingStore)) {
+		for (let bucket of asIterable<Bucket<K, V>>(this._backingStore)) {
 			if (DefaultEqualityComparator.INSTANCE.equals(o, bucket.value)) {
 				return true;
 			}
@@ -353,19 +353,19 @@ class ValueCollection<K, V> implements JavaCollection<V> {
 			return false;
 		}
 
-		return this.backingStore.equals(o.backingStore);
+		return this._backingStore.equals(o._backingStore);
 	}
 
 	hashCode(): number {
-		return this.backingStore.hashCode();
+		return this._backingStore.hashCode();
 	}
 
 	get isEmpty(): boolean {
-		return this.backingStore.isEmpty;
+		return this._backingStore.isEmpty;
 	}
 
 	iterator(): JavaIterator<V> {
-		let delegate: JavaIterator<Bucket<K, V>> = this.backingStore.iterator();
+		let delegate: JavaIterator<Bucket<K, V>> = this._backingStore.iterator();
 		return {
 			hasNext(): boolean {
 				return delegate.hasNext();
@@ -399,18 +399,18 @@ class ValueCollection<K, V> implements JavaCollection<V> {
 	}
 
 	get size(): number {
-		return this.backingStore.size;
+		return this._backingStore.size;
 	}
 
 	toArray(): V[];
 	toArray(a: V[]): V[];
 	toArray(a?: V[]): V[] {
-		if (a === undefined || a.length < this.backingStore.size) {
-			a = new Array<V>(this.backingStore.size);
+		if (a === undefined || a.length < this._backingStore.size) {
+			a = new Array<V>(this._backingStore.size);
 		}
 
 		let i = 0;
-		for (let bucket of asIterable<Bucket<K, V>>(this.backingStore)) {
+		for (let bucket of asIterable<Bucket<K, V>>(this._backingStore)) {
 			a[i++] = bucket.value!;
 		}
 

--- a/src/misc/Array2DHashSet.ts
+++ b/src/misc/Array2DHashSet.ts
@@ -420,16 +420,16 @@ class SetIterator<T> implements JavaIterator<T>  {
 	nextIndex: number = 0;
 	removed: boolean = true;
 
-	constructor(private data: T[], private set: Array2DHashSet<T>) { }
+	constructor(private _data: T[], private _set: Array2DHashSet<T>) { }
 
 	public hasNext(): boolean {
-		return this.nextIndex < this.data.length;
+		return this.nextIndex < this._data.length;
 	}
 
 	next(): T {
-		if (this.nextIndex >= this.data.length) throw new RangeError("Attempted to iterate past end.")
+		if (this.nextIndex >= this._data.length) throw new RangeError("Attempted to iterate past end.")
 		this.removed = false;
-		return this.data[this.nextIndex++];
+		return this._data[this.nextIndex++];
 	}
 
 	// Note: this is an untested extension to the JavaScript iterator interface
@@ -438,7 +438,7 @@ class SetIterator<T> implements JavaIterator<T>  {
 			throw new Error("This entry has already been removed");
 		}
 
-		this.set.remove(this.data[this.nextIndex - 1]);
+		this._set.remove(this._data[this.nextIndex - 1]);
 		this.removed = true;
 	}
 }

--- a/src/misc/BitSet.ts
+++ b/src/misc/BitSet.ts
@@ -80,7 +80,7 @@ for (let i = 0; i < 16; i++) {
 }
 
 export class BitSet implements Iterable<number>{
-	private data: Uint16Array;
+	private _data: Uint16Array;
 
 	/**
 	 * Creates a new bit set. All bits are initially `false`.
@@ -104,22 +104,22 @@ export class BitSet implements Iterable<number>{
 	constructor(arg?: number | Iterable<number>) {
 		if (!arg) {
 			// covering the case of unspecified and nbits===0
-			this.data = EMPTY_DATA;
+			this._data = EMPTY_DATA;
 		} else if (typeof arg === "number") {
 			if (arg < 0) {
 				throw new RangeError("nbits cannot be negative");
 			} else {
-				this.data = new Uint16Array(getIndex(arg - 1) + 1);
+				this._data = new Uint16Array(getIndex(arg - 1) + 1);
 			}
 		} else {
 			if (arg instanceof BitSet) {
-				this.data = arg.data.slice(0); // Clone the data
+				this._data = arg._data.slice(0); // Clone the data
 			} else {
 				let max = -1;
 				for (let v of arg) {
 					if (max < v) max = v;
 				}
-				this.data = new Uint16Array(getIndex(max - 1) + 1);
+				this._data = new Uint16Array(getIndex(max - 1) + 1);
 				for (let v of arg) {
 					this.set(v);
 				}
@@ -133,8 +133,8 @@ export class BitSet implements Iterable<number>{
 	 * bit in the bit set argument also had the value `true`.
 	 */
 	and(set: BitSet): void {
-		const data = this.data;
-		const other = set.data;
+		const data = this._data;
+		const other = set._data;
 		const words = Math.min(data.length, other.length);
 
 		let lastWord = -1;	// Keep track of index of last non-zero word
@@ -146,11 +146,11 @@ export class BitSet implements Iterable<number>{
 		}
 
 		if (lastWord === -1) {
-			this.data = EMPTY_DATA;
+			this._data = EMPTY_DATA;
 		}
 
 		if (lastWord < data.length - 1) {
-			this.data = data.slice(0, lastWord + 1);
+			this._data = data.slice(0, lastWord + 1);
 		}
 	}
 
@@ -158,8 +158,8 @@ export class BitSet implements Iterable<number>{
 	 * Clears all of the bits in this `BitSet` whose corresponding bit is set in the specified `BitSet`.
 	 */
 	andNot(set: BitSet): void {
-		const data = this.data;
-		const other = set.data;
+		const data = this._data;
+		const other = set._data;
 		const words = Math.min(data.length, other.length);
 
 		let lastWord = -1;	// Keep track of index of last non-zero word
@@ -171,11 +171,11 @@ export class BitSet implements Iterable<number>{
 		}
 
 		if (lastWord === -1) {
-			this.data = EMPTY_DATA;
+			this._data = EMPTY_DATA;
 		}
 
 		if (lastWord < data.length - 1) {
-			this.data = data.slice(0, lastWord + 1);
+			this._data = data.slice(0, lastWord + 1);
 		}
 	}
 
@@ -187,7 +187,7 @@ export class BitSet implements Iterable<number>{
 		if (this.isEmpty) {
 			return 0;
 		}
-		const data = this.data;
+		const data = this._data;
 		const length = data.length;
 		let result = 0;
 
@@ -223,7 +223,7 @@ export class BitSet implements Iterable<number>{
 	clear(fromIndex: number, toIndex: number): void;
 	clear(fromIndex?: number, toIndex?: number): void {
 		if (fromIndex == null) {
-			this.data.fill(0);
+			this._data.fill(0);
 		} else if (toIndex == null) {
 			this.set(fromIndex, false);
 		} else {
@@ -260,13 +260,13 @@ export class BitSet implements Iterable<number>{
 		const lastWord = getIndex(toIndex);
 
 		if (word === lastWord) {
-			this.data[word] ^= bitsFor(fromIndex, toIndex);
+			this._data[word] ^= bitsFor(fromIndex, toIndex);
 		} else {
-			this.data[word++] ^= bitsFor(fromIndex, 15);
+			this._data[word++] ^= bitsFor(fromIndex, 15);
 			while (word < lastWord) {
-				this.data[word++] ^= 0xFFFF;
+				this._data[word++] ^= 0xFFFF;
 			}
-			this.data[word++] ^= bitsFor(0, toIndex)
+			this._data[word++] ^= bitsFor(0, toIndex)
 		}
 	}
 
@@ -291,7 +291,7 @@ export class BitSet implements Iterable<number>{
 	get(fromIndex: number, toIndex: number): BitSet;
 	get(fromIndex: number, toIndex?: number): boolean | BitSet {
 		if (toIndex === undefined) {
-			return !!(this.data[getIndex(fromIndex)] & bitsFor(fromIndex, fromIndex));
+			return !!(this._data[getIndex(fromIndex)] & bitsFor(fromIndex, fromIndex));
 		} else {
 			// return a BitSet
 			let result = new BitSet(toIndex + 1);
@@ -315,7 +315,7 @@ export class BitSet implements Iterable<number>{
 
 		let bound = getIndex(smallerLength - 1);
 		for (let i = 0; i <= bound; i++) {
-			if ((this.data[i] & set.data[i]) !== 0) {
+			if ((this._data[i] & set._data[i]) !== 0) {
 				return true;
 			}
 		}
@@ -335,8 +335,8 @@ export class BitSet implements Iterable<number>{
 	 * zero if the `BitSet` contains no set bits.
 	 */
 	length(): number {
-		if (!this.data.length) return 0;
-		return this.previousSetBit(unIndex(this.data.length) - 1) + 1;
+		if (!this._data.length) return 0;
+		return this.previousSetBit(unIndex(this._data.length) - 1) + 1;
 	}
 
 	/**
@@ -352,7 +352,7 @@ export class BitSet implements Iterable<number>{
 			throw new RangeError("fromIndex cannot be negative");
 		}
 
-		const data = this.data;
+		const data = this._data;
 		const length = data.length;
 		let word = getIndex(fromIndex);
 		if (word > length) return -1;
@@ -391,7 +391,7 @@ export class BitSet implements Iterable<number>{
 			throw new RangeError("fromIndex cannot be negative");
 		}
 
-		const data = this.data;
+		const data = this._data;
 		const length = data.length;
 		let word = getIndex(fromIndex);
 		if (word > length) return -1;
@@ -414,8 +414,8 @@ export class BitSet implements Iterable<number>{
 	 * set argument has the value `true`.
 	 */
 	or(set: BitSet): void {
-		const data = this.data;
-		const other = set.data;
+		const data = this._data;
+		const other = set._data;
 		const minWords = Math.min(data.length, other.length);
 		const words = Math.max(data.length, other.length);
 		const dest = data.length === words ? data : new Uint16Array(words);
@@ -436,11 +436,11 @@ export class BitSet implements Iterable<number>{
 		}
 
 		if (lastWord === -1) {
-			this.data = EMPTY_DATA;
+			this._data = EMPTY_DATA;
 		} else if (dest.length === lastWord + 1) {
-			this.data = dest;
+			this._data = dest;
 		} else {
-			this.data = dest.slice(0, lastWord);
+			this._data = dest.slice(0, lastWord);
 		}
 	}
 
@@ -457,7 +457,7 @@ export class BitSet implements Iterable<number>{
 			throw new RangeError("fromIndex cannot be negative");
 		}
 
-		const data = this.data;
+		const data = this._data;
 		const length = data.length;
 		let word = getIndex(fromIndex);
 		if (word >= length) word = length - 1;
@@ -497,7 +497,7 @@ export class BitSet implements Iterable<number>{
 			throw new RangeError("fromIndex cannot be negative");
 		}
 
-		const data = this.data;
+		const data = this._data;
 		const length = data.length;
 		let word = getIndex(fromIndex);
 		if (word >= length) word = length - 1;
@@ -575,19 +575,19 @@ export class BitSet implements Iterable<number>{
 		let word = getIndex(fromIndex);
 		let lastWord = getIndex(toIndex);
 
-		if (value && lastWord >= this.data.length) {
+		if (value && lastWord >= this._data.length) {
 			// Grow array "just enough" for bits we need to set
 			var temp = new Uint16Array(lastWord + 1);
-			this.data.forEach((value, index) => temp[index] = value);
-			this.data = temp;
+			this._data.forEach((value, index) => temp[index] = value);
+			this._data = temp;
 		} else if (!value) {
 			// But there is no need to grow array to clear bits.
-			if (word >= this.data.length)
+			if (word >= this._data.length)
 				return; // Early exit
-			if (lastWord >= this.data.length) {
+			if (lastWord >= this._data.length) {
 				// Adjust work to fit array
-				lastWord = this.data.length - 1;
-				toIndex = this.data.length * 16 - 1;
+				lastWord = this._data.length - 1;
+				toIndex = this._data.length * 16 - 1;
 			}
 		}
 
@@ -596,7 +596,7 @@ export class BitSet implements Iterable<number>{
 		} else {
 			this._setBits(word++, value, bitsFor(fromIndex, 15));
 			while (word < lastWord) {
-				this.data[word++] = value ? 0xFFFF : 0;
+				this._data[word++] = value ? 0xFFFF : 0;
 			}
 			this._setBits(word, value, bitsFor(0, toIndex));
 		}
@@ -604,9 +604,9 @@ export class BitSet implements Iterable<number>{
 
 	private _setBits(word: number, value: boolean, mask: number) {
 		if (value) {
-			this.data[word] |= mask;
+			this._data[word] |= mask;
 		} else {
-			this.data[word] &= 0xFFFF ^ mask;
+			this._data[word] &= 0xFFFF ^ mask;
 		}
 	}
 
@@ -615,7 +615,7 @@ export class BitSet implements Iterable<number>{
 	 * in the set is the size - 1st element.
 	 */
 	get size(): number {
-		return this.data.byteLength * 8;
+		return this._data.byteLength * 8;
 	}
 
 	/**
@@ -643,7 +643,7 @@ export class BitSet implements Iterable<number>{
 	// }
 
 	hashCode(): number {
-		return MurmurHash.hashCode(this.data, 22);
+		return MurmurHash.hashCode(this._data, 22);
 	}
 
 	/**
@@ -674,7 +674,7 @@ export class BitSet implements Iterable<number>{
 
 		let bound = getIndex(len - 1);
 		for (let i = 0; i <= bound; i++) {
-			if (this.data[i] !== obj.data[i]) {
+			if (this._data[i] !== obj._data[i]) {
 				return false;
 			}
 		}
@@ -736,8 +736,8 @@ export class BitSet implements Iterable<number>{
 	 * * The bit initially has the value `false`, and the corresponding bit in the argument has the value `true`.
 	 */
 	xor(set: BitSet): void {
-		const data = this.data;
-		const other = set.data;
+		const data = this._data;
+		const other = set._data;
 		const minWords = Math.min(data.length, other.length);
 		const words = Math.max(data.length, other.length);
 		const dest = data.length === words ? data : new Uint16Array(words);
@@ -758,11 +758,11 @@ export class BitSet implements Iterable<number>{
 		}
 
 		if (lastWord === -1) {
-			this.data = EMPTY_DATA;
+			this._data = EMPTY_DATA;
 		} else if (dest.length === lastWord + 1) {
-			this.data = dest;
+			this._data = dest;
 		} else {
-			this.data = dest.slice(0, lastWord + 1);
+			this._data = dest.slice(0, lastWord + 1);
 		}
 	}
 
@@ -771,7 +771,7 @@ export class BitSet implements Iterable<number>{
 	}
 
 	[Symbol.iterator](): IterableIterator<number> {
-		return new BitSetIterator(this.data);
+		return new BitSetIterator(this._data);
 	}
 
 	// Overrides formatting for nodejs assert etc.
@@ -781,21 +781,21 @@ export class BitSet implements Iterable<number>{
 }
 
 class BitSetIterator implements IterableIterator<number>{
-	private index = 0;
-	private mask = 0xFFFF;
+	private _index = 0;
+	private _mask = 0xFFFF;
 
 	constructor(private data: Uint16Array) { }
 
 	next() {
-		while (this.index < this.data.length) {
-			const bits = this.data[this.index] & this.mask;;
+		while (this._index < this.data.length) {
+			const bits = this.data[this._index] & this._mask;;
 			if (bits !== 0) {
-				const bitNumber = unIndex(this.index) + findLSBSet(bits);
-				this.mask = bitsFor(bitNumber + 1, 15);
+				const bitNumber = unIndex(this._index) + findLSBSet(bits);
+				this._mask = bitsFor(bitNumber + 1, 15);
 				return { done: false, value: bitNumber };
 			}
-			this.index++;
-			this.mask = 0xFFFF;
+			this._index++;
+			this._mask = 0xFFFF;
 		}
 		return { done: true, value: -1 };
 	}

--- a/src/misc/BitSet.ts
+++ b/src/misc/BitSet.ts
@@ -627,7 +627,7 @@ export class BitSet implements Iterable<number>{
 	 * `n < 8 * bytes.length`.
 	 */
 	// toByteArray(): Int8Array {
-	// 	throw "NOT IMPLEMENTED";
+	// 	throw new Error("NOT IMPLEMENTED");
 	// }
 
 	/**
@@ -639,7 +639,7 @@ export class BitSet implements Iterable<number>{
 	 * `n < 32 * integers.length`.
 	 */
 	// toIntegerArray(): Int32Array {
-	// 	throw "NOT IMPLEMENTED";
+	// 	throw new Error("NOT IMPLEMENTED");
 	// }
 
 	hashCode(): number {
@@ -725,7 +725,7 @@ export class BitSet implements Iterable<number>{
 	// static valueOf(buffer: ArrayBuffer): BitSet;
 	// static valueOf(integers: Int32Array): BitSet;
 	// static valueOf(data: Int8Array | Int32Array | ArrayBuffer): BitSet {
-	// 	throw "NOT IMPLEMENTED";
+	// 	throw new Error("NOT IMPLEMENTED");
 	// }
 
 	/**

--- a/src/misc/IntegerList.ts
+++ b/src/misc/IntegerList.ts
@@ -51,7 +51,7 @@ export class IntegerList {
 
 	add(value: number): void {
 		if (this._data.length === this._size) {
-			this.ensureCapacity(this._size + 1);
+			this._ensureCapacity(this._size + 1);
 		}
 
 		this._data[this._size] = value;
@@ -60,16 +60,16 @@ export class IntegerList {
 
 	addAll(list: number[] | IntegerList | JavaCollection<number>): void {
 		if (Array.isArray(list)) {
-			this.ensureCapacity(this._size + list.length);
+			this._ensureCapacity(this._size + list.length);
 			this._data.subarray(this._size, this._size + list.length).set(list);
 			this._size += list.length;
 		} else if (list instanceof IntegerList) {
-			this.ensureCapacity(this._size + list._size);
+			this._ensureCapacity(this._size + list._size);
 			this._data.subarray(this._size, this._size + list.size).set(list._data);
 			this._size += list._size;
 		} else {
 			// list is JavaCollection<number>
-			this.ensureCapacity(this._size + list.size);
+			this._ensureCapacity(this._size + list.size);
 			let current: number = 0;
 			for (let xi = list.iterator(); xi.hasNext(); /*empty*/) {
 				this._data[this._size + current] = xi.next();
@@ -251,7 +251,7 @@ export class IntegerList {
 		return Arrays.binarySearch(this._data, key, fromIndex, toIndex);
 	}
 
-	private ensureCapacity(capacity: number): void {
+	private _ensureCapacity(capacity: number): void {
 		if (capacity < 0 || capacity > MAX_ARRAY_SIZE) {
 			throw new RangeError();
 		}

--- a/src/misc/Interval.ts
+++ b/src/misc/Interval.ts
@@ -17,7 +17,7 @@ export class Interval implements Equatable {
 		return Interval._INVALID;
 	}
 
-	private static readonly cache: Interval[] = new Array<Interval>(INTERVAL_POOL_MAX_VALUE + 1);
+	private static readonly _cache: Interval[] = new Array<Interval>(INTERVAL_POOL_MAX_VALUE + 1);
 
 	/**
 	 * @param a The start of the interval
@@ -38,11 +38,11 @@ export class Interval implements Equatable {
 			return new Interval(a, b);
 		}
 
-		if (Interval.cache[a] == null) {
-			Interval.cache[a] = new Interval(a, a);
+		if (Interval._cache[a] == null) {
+			Interval._cache[a] = new Interval(a, a);
 		}
 
-		return Interval.cache[a];
+		return Interval._cache[a];
 	}
 
 	/** return number of elements between a and b inclusively. x..x is length 1.

--- a/src/misc/IntervalSet.ts
+++ b/src/misc/IntervalSet.ts
@@ -74,7 +74,7 @@ export class IntervalSet implements IntSet {
 
 	clear(): void {
 		if (this.readonly) {
-			throw "can't alter readonly IntervalSet";
+			throw new Error("can't alter readonly IntervalSet");
 		}
 
 		this._intervals.length = 0;
@@ -94,7 +94,7 @@ export class IntervalSet implements IntSet {
 	// copy on write so we can cache a..a intervals and sets of that
 	protected addRange(addition: Interval): void {
 		if (this.readonly) {
-			throw "can't alter readonly IntervalSet";
+			throw new Error("can't alter readonly IntervalSet");
 		}
 
 		//System.out.println("add "+addition+" to "+intervals.toString());
@@ -661,7 +661,7 @@ export class IntervalSet implements IntSet {
 	@Override
 	remove(el: number): void {
 		if (this.readonly) {
-			throw "can't alter readonly IntervalSet";
+			throw new Error("can't alter readonly IntervalSet");
 		}
 
 		let n: number = this._intervals.length;
@@ -702,7 +702,7 @@ export class IntervalSet implements IntSet {
 
 	setReadonly(readonly: boolean): void {
 		if (this.readonly && !readonly) {
-			throw "can't alter readonly IntervalSet";
+			throw new Error("can't alter readonly IntervalSet");
 		}
 
 		this.readonly = readonly;

--- a/src/misc/IntervalSet.ts
+++ b/src/misc/IntervalSet.ts
@@ -51,7 +51,7 @@ export class IntervalSet implements IntSet {
 	/** The list of sorted, disjoint intervals. */
 	private _intervals: Interval[];
 
-	private readonly: boolean = false;
+	private _readonly: boolean = false;
 
 	constructor(intervals?: Interval[]) {
 		if (intervals != null) {
@@ -73,7 +73,7 @@ export class IntervalSet implements IntSet {
 	}
 
 	clear(): void {
-		if (this.readonly) {
+		if (this._readonly) {
 			throw new Error("can't alter readonly IntervalSet");
 		}
 
@@ -93,7 +93,7 @@ export class IntervalSet implements IntSet {
 
 	// copy on write so we can cache a..a intervals and sets of that
 	protected addRange(addition: Interval): void {
-		if (this.readonly) {
+		if (this._readonly) {
 			throw new Error("can't alter readonly IntervalSet");
 		}
 
@@ -660,7 +660,7 @@ export class IntervalSet implements IntSet {
 
 	@Override
 	remove(el: number): void {
-		if (this.readonly) {
+		if (this._readonly) {
 			throw new Error("can't alter readonly IntervalSet");
 		}
 
@@ -697,14 +697,14 @@ export class IntervalSet implements IntSet {
 	}
 
 	get isReadonly(): boolean {
-		return this.readonly;
+		return this._readonly;
 	}
 
 	setReadonly(readonly: boolean): void {
-		if (this.readonly && !readonly) {
+		if (this._readonly && !readonly) {
 			throw new Error("can't alter readonly IntervalSet");
 		}
 
-		this.readonly = readonly;
+		this._readonly = readonly;
 	}
 }

--- a/src/misc/IntervalSet.ts
+++ b/src/misc/IntervalSet.ts
@@ -88,11 +88,11 @@ export class IntervalSet implements IntSet {
 	 *  {1..5, 6..7, 10..20}.  Adding 4..8 yields {1..8, 10..20}.
 	 */
 	add(a: number, b: number = a): void {
-		this.addRange(Interval.of(a, b));
+		this._addRange(Interval.of(a, b));
 	}
 
 	// copy on write so we can cache a..a intervals and sets of that
-	protected addRange(addition: Interval): void {
+	protected _addRange(addition: Interval): void {
 		if (this._readonly) {
 			throw new Error("can't alter readonly IntervalSet");
 		}
@@ -345,7 +345,7 @@ export class IntervalSet implements IntSet {
 					intersection = new IntervalSet();
 				}
 
-				intersection.addRange(mine.intersection(theirs));
+				intersection._addRange(mine.intersection(theirs));
 				j++;
 			}
 			else if (theirs.properlyContains(mine)) {
@@ -354,7 +354,7 @@ export class IntervalSet implements IntSet {
 					intersection = new IntervalSet();
 				}
 
-				intersection.addRange(mine.intersection(theirs));
+				intersection._addRange(mine.intersection(theirs));
 				i++;
 			}
 			else if (!mine.disjoint(theirs)) {
@@ -363,7 +363,7 @@ export class IntervalSet implements IntSet {
 					intersection = new IntervalSet();
 				}
 
-				intersection.addRange(mine.intersection(theirs));
+				intersection._addRange(mine.intersection(theirs));
 				// Move the iterator of lower range [a..b], but not
 				// the upper range as it may contain elements that will collide
 				// with the next iterator. So, if mine=[0..115] and
@@ -563,14 +563,14 @@ export class IntervalSet implements IntSet {
 			let a: number = I.a;
 			let b: number = I.b;
 			if (a === b) {
-				buf += this.elementName(vocabulary, a);
+				buf += this._elementName(vocabulary, a);
 			} else {
 				for (let i = a; i <= b; i++) {
 					if (i > a) {
 						buf += ", ";
 					}
 
-					buf += this.elementName(vocabulary, i);
+					buf += this._elementName(vocabulary, i);
 				}
 			}
 		}
@@ -583,7 +583,7 @@ export class IntervalSet implements IntSet {
 	}
 
 	@NotNull
-	protected elementName( @NotNull vocabulary: Vocabulary, a: number): string {
+	protected _elementName( @NotNull vocabulary: Vocabulary, a: number): string {
 		if (a === Token.EOF) {
 			return "<EOF>";
 		} else if (a === Token.EPSILON) {

--- a/src/misc/ParseCancellationException.ts
+++ b/src/misc/ParseCancellationException.ts
@@ -14,7 +14,7 @@
  * @author Sam Harwell
  */
 export class ParseCancellationException extends Error {
-	// private static serialVersionUID: number =  -3529552099366979683L;
+	// private static _serialVersionUID: number =  -3529552099366979683L;
 	readonly stack?: string;
 
 	constructor(public cause: Error) {

--- a/src/misc/Stubs.ts
+++ b/src/misc/Stubs.ts
@@ -104,9 +104,9 @@ export function asIterable<T>(collection: Collection<T>): Iterable<T> {
 
 class IterableAdapter<T> implements Iterable<T>, IterableIterator<T> {
 	private _iterator: JavaIterator<T>
-	constructor(private collection: JavaCollection<T>) { }
+	constructor(private _collection: JavaCollection<T>) { }
 
-	[Symbol.iterator]() { this._iterator = this.collection.iterator(); return this; }
+	[Symbol.iterator]() { this._iterator = this._collection.iterator(); return this; }
 
 	next(): IteratorResult<T> {
 		if (!this._iterator.hasNext()) {

--- a/src/misc/UUID.ts
+++ b/src/misc/UUID.ts
@@ -7,14 +7,14 @@ import { Equatable } from './Stubs';
 import { MurmurHash } from './MurmurHash';
 
 export class UUID implements Equatable {
-	private readonly data: Uint32Array;
+	private readonly _data: Uint32Array;
 
 	constructor(mostSigBits: number, moreSigBits: number, lessSigBits: number, leastSigBits: number) {
-		this.data = new Uint32Array(4);
-		this.data[0] = mostSigBits;
-		this.data[1] = moreSigBits;
-		this.data[2] = lessSigBits;
-		this.data[3] = leastSigBits;
+		this._data = new Uint32Array(4);
+		this._data[0] = mostSigBits;
+		this._data[1] = moreSigBits;
+		this._data[2] = lessSigBits;
+		this._data[3] = leastSigBits;
 	}
 
 	static fromString(data: string): UUID {
@@ -31,7 +31,7 @@ export class UUID implements Equatable {
 	}
 
 	hashCode(): number {
-		return MurmurHash.hashCode([this.data[0], this.data[1], this.data[2], this.data[3]]);
+		return MurmurHash.hashCode([this._data[0], this._data[1], this._data[2], this._data[3]]);
 	}
 
 	equals(obj: any): boolean {
@@ -41,18 +41,18 @@ export class UUID implements Equatable {
 			return false;
 		}
 
-		return this.data[0] === obj.data[0]
-			&& this.data[1] === obj.data[1]
-			&& this.data[2] === obj.data[2]
-			&& this.data[3] === obj.data[3];
+		return this._data[0] === obj._data[0]
+			&& this._data[1] === obj._data[1]
+			&& this._data[2] === obj._data[2]
+			&& this._data[3] === obj._data[3];
 	}
 
 	toString(): string {
-		return ("00000000" + this.data[0].toString(16)).substr(-8)
-			+ "-" + ("0000" + (this.data[1] >>> 16).toString(16)).substr(-4)
-			+ "-" + ("0000" + this.data[1].toString(16)).substr(-4)
-			+ "-" + ("0000" + (this.data[2] >>> 16).toString(16)).substr(-4)
-			+ "-" + ("0000" + this.data[2].toString(16)).substr(-4)
-			+ ("00000000" + this.data[3].toString(16)).substr(-8);
+		return ("00000000" + this._data[0].toString(16)).substr(-8)
+			+ "-" + ("0000" + (this._data[1] >>> 16).toString(16)).substr(-4)
+			+ "-" + ("0000" + this._data[1].toString(16)).substr(-4)
+			+ "-" + ("0000" + (this._data[2] >>> 16).toString(16)).substr(-4)
+			+ "-" + ("0000" + this._data[2].toString(16)).substr(-4)
+			+ ("00000000" + this._data[3].toString(16)).substr(-8);
 	}
 }

--- a/src/tree/AbstractParseTreeVisitor.ts
+++ b/src/tree/AbstractParseTreeVisitor.ts
@@ -41,16 +41,16 @@ export abstract class AbstractParseTreeVisitor<Result> implements ParseTreeVisit
 	 */
 	@Override
 	visitChildren(@NotNull node: RuleNode): Result {
-		let result: Result = this.defaultResult();
+		let result: Result = this._defaultResult();
 		let n: number = node.childCount;
 		for (let i = 0; i < n; i++) {
-			if (!this.shouldVisitNextChild(node, result)) {
+			if (!this._shouldVisitNextChild(node, result)) {
 				break;
 			}
 
 			let c: ParseTree = node.getChild(i);
 			let childResult: Result = c.accept(this);
-			result = this.aggregateResult(result, childResult);
+			result = this._aggregateResult(result, childResult);
 		}
 
 		return result;
@@ -64,7 +64,7 @@ export abstract class AbstractParseTreeVisitor<Result> implements ParseTreeVisit
 	 */
 	@Override
 	visitTerminal(@NotNull node: TerminalNode): Result {
-		return this.defaultResult();
+		return this._defaultResult();
 	}
 
 	/**
@@ -75,7 +75,7 @@ export abstract class AbstractParseTreeVisitor<Result> implements ParseTreeVisit
 	 */
 	@Override
 	visitErrorNode(@NotNull node: ErrorNode): Result {
-		return this.defaultResult();
+		return this._defaultResult();
 	}
 
 	/**
@@ -87,7 +87,7 @@ export abstract class AbstractParseTreeVisitor<Result> implements ParseTreeVisit
 	 *
 	 * @return The default value returned by visitor methods.
 	 */
-	protected abstract defaultResult(): Result;
+	protected abstract _defaultResult(): Result;
 
 	/**
 	 * Aggregates the results of visiting multiple children of a node. After
@@ -108,7 +108,7 @@ export abstract class AbstractParseTreeVisitor<Result> implements ParseTreeVisit
 	 *
 	 * @return The updated aggregate result.
 	 */
-	protected aggregateResult(aggregate: Result, nextResult: Result): Result {
+	protected _aggregateResult(aggregate: Result, nextResult: Result): Result {
 		return nextResult;
 	}
 
@@ -136,7 +136,7 @@ export abstract class AbstractParseTreeVisitor<Result> implements ParseTreeVisit
 	 * {@code false} to stop visiting children and immediately return the
 	 * current aggregate result from {@link #visitChildren}.
 	 */
-	protected shouldVisitNextChild(@NotNull node: RuleNode, currentResult: Result): boolean {
+	protected _shouldVisitNextChild(@NotNull node: RuleNode, currentResult: Result): boolean {
 		return true;
 	}
 }

--- a/src/tree/ParseTreeWalker.ts
+++ b/src/tree/ParseTreeWalker.ts
@@ -30,7 +30,7 @@ export class ParseTreeWalker {
 					listener.visitTerminal(currentNode);
 				}
 			} else {
-				this.enterRule(listener, currentNode as RuleNode);
+				this._enterRule(listener, currentNode as RuleNode);
 			}
 
 			// Move down to first child, if exists
@@ -46,7 +46,7 @@ export class ParseTreeWalker {
 			do {
 				// post-order visit
 				if (currentNode instanceof RuleNode) {
-					this.exitRule(listener, currentNode);
+					this._exitRule(listener, currentNode);
 				}
 
 				// No parent, so no siblings
@@ -77,7 +77,7 @@ export class ParseTreeWalker {
 	 * {@link RuleContext}-specific event. First we trigger the generic and then
 	 * the rule specific. We to them in reverse order upon finishing the node.
 	 */
-	protected enterRule(listener: ParseTreeListener, r: RuleNode): void {
+	protected _enterRule(listener: ParseTreeListener, r: RuleNode): void {
 		let ctx = r.ruleContext as ParserRuleContext;
 		if (listener.enterEveryRule) {
 			listener.enterEveryRule(ctx);
@@ -86,7 +86,7 @@ export class ParseTreeWalker {
 		ctx.enterRule(listener);
 	}
 
-	protected exitRule(listener: ParseTreeListener, r: RuleNode): void {
+	protected _exitRule(listener: ParseTreeListener, r: RuleNode): void {
 		let ctx = r.ruleContext as ParserRuleContext;
 		ctx.exitRule(listener);
 		if (listener.exitEveryRule) {

--- a/src/tree/pattern/RuleTagToken.ts
+++ b/src/tree/pattern/RuleTagToken.ts
@@ -24,7 +24,7 @@ export class RuleTagToken implements Token {
 	 * The token type for the current token. This is the token type assigned to
 	 * the bypass alternative for the rule during ATN deserialization.
 	 */
-	private bypassTokenType: number;
+	private _bypassTokenType: number;
 	/**
 	 * This is the backing field for `label`.
 	 */
@@ -48,7 +48,7 @@ export class RuleTagToken implements Token {
 		}
 
 		this._ruleName = ruleName;
-		this.bypassTokenType = bypassTokenType;
+		this._bypassTokenType = bypassTokenType;
 		this._label = label;
 	}
 
@@ -105,7 +105,7 @@ export class RuleTagToken implements Token {
 	 */
 	@Override
 	get type(): number {
-		return this.bypassTokenType;
+		return this._bypassTokenType;
 	}
 
 	/**
@@ -186,6 +186,6 @@ export class RuleTagToken implements Token {
 	 */
 	@Override
 	toString(): string {
-		return this._ruleName + ":" + this.bypassTokenType;
+		return this._ruleName + ":" + this._bypassTokenType;
 	}
 }

--- a/src/tree/xpath/XPath.ts
+++ b/src/tree/xpath/XPath.ts
@@ -70,14 +70,14 @@ export class XPath {
 	static readonly WILDCARD: string = "*"; // word not operator/separator
 	static readonly NOT: string = "!"; 	   // word for invert operator
 
-	protected path: string;
-	protected elements: XPathElement[];
-	protected parser: Parser;
+	protected _path: string;
+	protected _elements: XPathElement[];
+	protected _parser: Parser;
 
 	constructor(parser: Parser, path: string) {
-		this.parser = parser;
-		this.path = path;
-		this.elements = this.split(path);
+		this._parser = parser;
+		this._path = path;
+		this._elements = this.split(path);
 //		System.out.println(Arrays.toString(elements));
 	}
 
@@ -123,7 +123,7 @@ export class XPath {
 						i++;
 						next = tokens[i];
 					}
-					let pathElement: XPathElement = this.getXPathElement(next, anywhere);
+					let pathElement: XPathElement = this._getXPathElement(next, anywhere);
 					pathElement.invert = invert;
 					elements.push(pathElement);
 					i++;
@@ -132,7 +132,7 @@ export class XPath {
 				case XPathLexer.TOKEN_REF:
 				case XPathLexer.RULE_REF:
 				case XPathLexer.WILDCARD:
-					elements.push(this.getXPathElement(el, false));
+					elements.push(this._getXPathElement(el, false));
 					i++;
 					break;
 
@@ -151,7 +151,7 @@ export class XPath {
 	 * element. {@code anywhere} is {@code true} if {@code //} precedes the
 	 * word.
 	 */
-	protected getXPathElement(wordToken: Token, anywhere: boolean): XPathElement {
+	protected _getXPathElement(wordToken: Token, anywhere: boolean): XPathElement {
 		if (wordToken.type == Token.EOF) {
 			throw new Error("Missing path element at end of path");
 		}
@@ -161,8 +161,8 @@ export class XPath {
 			throw new Error("Expected wordToken to have text content.");
 		}
 
-		let ttype: number = this.parser.getTokenType(word);
-		let ruleIndex: number = this.parser.getRuleIndex(word);
+		let ttype: number = this._parser.getTokenType(word);
+		let ruleIndex: number = this._parser.getRuleIndex(word);
 		switch (wordToken.type) {
 			case XPathLexer.WILDCARD:
 				return anywhere ?
@@ -207,14 +207,14 @@ export class XPath {
 		let work = [dummyRoot] as ParseTree[];
 
 		let i: number = 0;
-		while (i < this.elements.length) {
+		while (i < this._elements.length) {
 			let next = [] as ParseTree[]; // WAS LinkedHashSet<ParseTree>
 			for (let node of work) {
 				if (node.childCount > 0) {
 					// only try to match next element if it has children
 					// e.g., //func/*/stat might have a token node for which
 					// we can't go looking for stat nodes.
-					let matching = this.elements[i].evaluate(node);
+					let matching = this._elements[i].evaluate(node);
 					next = next.concat(matching);
 				}
 			}

--- a/src/tree/xpath/XPathElement.ts
+++ b/src/tree/xpath/XPathElement.ts
@@ -8,14 +8,14 @@ import { Override } from "../../Decorators";
 import { ParseTree } from "../ParseTree";
 
 export abstract class XPathElement {
-	protected nodeName: string;
+	protected _nodeName: string;
 	public invert: boolean;
 
 	/** Construct element like {@code /ID} or {@code ID} or {@code /*} etc...
 	 *  op is null if just node
 	 */
 	constructor(nodeName: string) {
-		this.nodeName = nodeName;
+		this._nodeName = nodeName;
 		this.invert = false;
 	}
 
@@ -29,6 +29,6 @@ export abstract class XPathElement {
 	toString(): string {
 		let inv: string = this.invert ? "!" : "";
 		let className: string = Object.constructor.name;
-		return className + "[" + inv + this.nodeName + "]";
+		return className + "[" + inv + this._nodeName + "]";
 	}
 }

--- a/src/tree/xpath/XPathRuleAnywhereElement.ts
+++ b/src/tree/xpath/XPathRuleAnywhereElement.ts
@@ -14,14 +14,14 @@ import { XPathElement } from "./XPathElement";
  * Either {@code ID} at start of path or {@code ...//ID} in middle of path.
  */
 export class XPathRuleAnywhereElement extends XPathElement {
-	protected ruleIndex: number;
+	protected _ruleIndex: number;
 	constructor(ruleName: string, ruleIndex: number) {
 		super(ruleName);
-		this.ruleIndex = ruleIndex;
+		this._ruleIndex = ruleIndex;
 	}
 
 	@Override
 	evaluate(t: ParseTree): ParseTree[] {
-		return Trees.findAllRuleNodes(t, this.ruleIndex);
+		return Trees.findAllRuleNodes(t, this._ruleIndex);
 	}
 }

--- a/src/tree/xpath/XPathRuleElement.ts
+++ b/src/tree/xpath/XPathRuleElement.ts
@@ -11,10 +11,10 @@ import { Trees } from "../Trees";
 import { XPathElement } from "./XPathElement";
 
 export class XPathRuleElement extends XPathElement {
-	protected ruleIndex: number;
+	protected _ruleIndex: number;
 	constructor(ruleName: string, ruleIndex: number) {
 		super(ruleName);
-		this.ruleIndex = ruleIndex;
+		this._ruleIndex = ruleIndex;
 	}
 
 	@Override
@@ -23,8 +23,8 @@ export class XPathRuleElement extends XPathElement {
 		let nodes: ParseTree[] = [];
 		for (let c of Trees.getChildren(t)) {
 			if (c instanceof ParserRuleContext) {
-				if ((c.ruleIndex === this.ruleIndex && !this.invert) ||
-					(c.ruleIndex !== this.ruleIndex && this.invert)) {
+				if ((c.ruleIndex === this._ruleIndex && !this.invert) ||
+					(c.ruleIndex !== this._ruleIndex && this.invert)) {
 					nodes.push(c);
 				}
 			}

--- a/src/tree/xpath/XPathTokenAnywhereElement.ts
+++ b/src/tree/xpath/XPathTokenAnywhereElement.ts
@@ -10,14 +10,14 @@ import { Trees } from "../Trees";
 import { XPathElement } from "./XPathElement";
 
 export class XPathTokenAnywhereElement extends XPathElement {
-	protected tokenType: number;
+	protected _tokenType: number;
 	constructor(tokenName: string, tokenType: number) {
 		super(tokenName);
-		this.tokenType = tokenType;
+		this._tokenType = tokenType;
 	}
 
 	@Override
 	evaluate(t: ParseTree): ParseTree[] {
-		return Trees.findAllTokenNodes(t, this.tokenType);
+		return Trees.findAllTokenNodes(t, this._tokenType);
 	}
 }

--- a/src/tree/xpath/XPathTokenElement.ts
+++ b/src/tree/xpath/XPathTokenElement.ts
@@ -11,10 +11,10 @@ import { Trees } from "../Trees";
 import { XPathElement } from "./XPathElement";
 
 export class XPathTokenElement extends XPathElement {
-	protected tokenType: number;
+	protected _tokenType: number;
 	constructor(tokenName: string, tokenType: number) {
 		super(tokenName);
-		this.tokenType = tokenType;
+		this._tokenType = tokenType;
 	}
 
 	@Override
@@ -23,8 +23,8 @@ export class XPathTokenElement extends XPathElement {
 		let nodes: ParseTree[] = [];
 		for (let c of Trees.getChildren(t)) {
 			if (c instanceof TerminalNode) {
-				if ((c.symbol.type == this.tokenType && !this.invert) ||
-					(c.symbol.type != this.tokenType && this.invert)) {
+				if ((c.symbol.type == this._tokenType && !this.invert) ||
+					(c.symbol.type != this._tokenType && this.invert)) {
 					nodes.push(c);
 				}
 			}

--- a/test/tool/TestGraphNodes.ts
+++ b/test/tool/TestGraphNodes.ts
@@ -16,7 +16,7 @@ import { PredictionContextCache } from '../../src/atn/PredictionContextCache';
 
 @suite
 export class TestGraphNodes {
-	private contextCache: PredictionContextCache = new PredictionContextCache();
+	private _contextCache: PredictionContextCache = new PredictionContextCache();
 
 	rootIsWildcard(): boolean { return true; }
 	fullCtx(): boolean { return false; }
@@ -30,7 +30,7 @@ export class TestGraphNodes {
 	}
 
 	@Test test_$_$(): void {
-		let r: PredictionContext =  this.contextCache.join(PredictionContext.EMPTY_LOCAL,
+		let r: PredictionContext =  this._contextCache.join(PredictionContext.EMPTY_LOCAL,
 													  PredictionContext.EMPTY_LOCAL);
 		// console.log(toDOTString(r));
 		let expecting: string =
@@ -42,7 +42,7 @@ export class TestGraphNodes {
 	}
 
 	@Test test_$_$_fullctx(): void {
-		let r: PredictionContext =  this.contextCache.join(PredictionContext.EMPTY_FULL,
+		let r: PredictionContext =  this._contextCache.join(PredictionContext.EMPTY_FULL,
 													  PredictionContext.EMPTY_FULL);
 		// console.log(toDOTString(r));
 		let expecting: string =
@@ -54,7 +54,7 @@ export class TestGraphNodes {
 	}
 
 	@Test test_x_$(): void {
-		let r: PredictionContext =  this.contextCache.join(this.x(false), PredictionContext.EMPTY_LOCAL);
+		let r: PredictionContext =  this._contextCache.join(this.x(false), PredictionContext.EMPTY_LOCAL);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -65,7 +65,7 @@ export class TestGraphNodes {
 	}
 
 	@Test test_x_$_fullctx(): void {
-		let r: PredictionContext =  this.contextCache.join(this.x(true), PredictionContext.EMPTY_FULL);
+		let r: PredictionContext =  this._contextCache.join(this.x(true), PredictionContext.EMPTY_FULL);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -78,7 +78,7 @@ export class TestGraphNodes {
 	}
 
 	@Test test_$_x(): void {
-		let r: PredictionContext =  this.contextCache.join(PredictionContext.EMPTY_LOCAL, this.x(false));
+		let r: PredictionContext =  this._contextCache.join(PredictionContext.EMPTY_LOCAL, this.x(false));
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -89,7 +89,7 @@ export class TestGraphNodes {
 	}
 
 	@Test test_$_x_fullctx(): void {
-		let r: PredictionContext =  this.contextCache.join(PredictionContext.EMPTY_FULL, this.x(true));
+		let r: PredictionContext =  this._contextCache.join(PredictionContext.EMPTY_FULL, this.x(true));
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -102,7 +102,7 @@ export class TestGraphNodes {
 	}
 
 	@Test test_a_a(): void {
-		let r: PredictionContext =  this.contextCache.join(this.a(false), this.a(false));
+		let r: PredictionContext =  this._contextCache.join(this.a(false), this.a(false));
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -118,7 +118,7 @@ export class TestGraphNodes {
 		let a1: PredictionContext =  this.a(false);
 		let xx: PredictionContext =  this.x(false);
 		let a2: PredictionContext =  this.createSingleton(xx, 1);
-		let r: PredictionContext =  this.contextCache.join(a1, a2);
+		let r: PredictionContext =  this._contextCache.join(a1, a2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -134,7 +134,7 @@ export class TestGraphNodes {
 		let a1: PredictionContext =  this.a(true);
 		let xx: PredictionContext =  this.x(true);
 		let a2: PredictionContext =  this.createSingleton(xx, 1);
-		let r: PredictionContext =  this.contextCache.join(a1, a2);
+		let r: PredictionContext =  this._contextCache.join(a1, a2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -152,7 +152,7 @@ export class TestGraphNodes {
 		let xx: PredictionContext =  this.x(false);
 		let a1: PredictionContext =  this.createSingleton(xx, 1);
 		let a2: PredictionContext =  this.a(false);
-		let r: PredictionContext =  this.contextCache.join(a1, a2);
+		let r: PredictionContext =  this._contextCache.join(a1, a2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -167,9 +167,9 @@ export class TestGraphNodes {
 	@Test test_aa$_a$_$_fullCtx(): void {
 		let empty: PredictionContext =  PredictionContext.EMPTY_FULL;
 		let child1: PredictionContext =  this.createSingleton(empty, 8);
-		let right: PredictionContext =  this.contextCache.join(empty, child1);
+		let right: PredictionContext =  this._contextCache.join(empty, child1);
 		let left: PredictionContext =  this.createSingleton(right, 8);
-		let merged: PredictionContext =  this.contextCache.join(left, right);
+		let merged: PredictionContext =  this._contextCache.join(left, right);
 		let actual: string =  toDOTString(merged);
 		// console.log(actual);
 		let expecting: string =
@@ -188,7 +188,7 @@ export class TestGraphNodes {
 		let xx: PredictionContext =  this.x(true);
 		let a1: PredictionContext =  this.createSingleton(xx, 1);
 		let a2: PredictionContext =  this.a(true);
-		let r: PredictionContext =  this.contextCache.join(a1, a2);
+		let r: PredictionContext =  this._contextCache.join(a1, a2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -203,7 +203,7 @@ export class TestGraphNodes {
 	}
 
 	@Test test_a_b(): void {
-		let r: PredictionContext =  this.contextCache.join(this.a(false), this.b(false));
+		let r: PredictionContext =  this._contextCache.join(this.a(false), this.b(false));
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -220,7 +220,7 @@ export class TestGraphNodes {
 		let xx: PredictionContext =  this.x(false);
 		let a1: PredictionContext =  this.createSingleton(xx, 1);
 		let a2: PredictionContext =  this.createSingleton(xx, 1);
-		let r: PredictionContext =  this.contextCache.join(a1, a2);
+		let r: PredictionContext =  this._contextCache.join(a1, a2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -239,7 +239,7 @@ export class TestGraphNodes {
 		let x2: PredictionContext =  this.x(false);
 		let a1: PredictionContext =  this.createSingleton(x1, 1);
 		let a2: PredictionContext =  this.createSingleton(x2, 1);
-		let r: PredictionContext =  this.contextCache.join(a1, a2);
+		let r: PredictionContext =  this._contextCache.join(a1, a2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -260,7 +260,7 @@ export class TestGraphNodes {
 		let b2: PredictionContext =  this.createSingleton(x2, 2);
 		let a1: PredictionContext =  this.createSingleton(b1, 1);
 		let a2: PredictionContext =  this.createSingleton(b2, 1);
-		let r: PredictionContext =  this.contextCache.join(a1, a2);
+		let r: PredictionContext =  this._contextCache.join(a1, a2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -283,7 +283,7 @@ export class TestGraphNodes {
 		let c: PredictionContext =  this.createSingleton(x2, 3);
 		let a1: PredictionContext =  this.createSingleton(b, 1);
 		let a2: PredictionContext =  this.createSingleton(c, 1);
-		let r: PredictionContext =  this.contextCache.join(a1, a2);
+		let r: PredictionContext =  this._contextCache.join(a1, a2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -304,7 +304,7 @@ export class TestGraphNodes {
 		let xx: PredictionContext = this.x(false);
 		let a: PredictionContext =  this.createSingleton(xx, 1);
 		let b: PredictionContext =  this.createSingleton(xx, 2);
-		let r: PredictionContext =  this.contextCache.join(a, b);
+		let r: PredictionContext =  this._contextCache.join(a, b);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -324,7 +324,7 @@ export class TestGraphNodes {
 		let x2: PredictionContext =  this.x(false);
 		let a: PredictionContext =  this.createSingleton(x1, 1);
 		let b: PredictionContext =  this.createSingleton(x2, 2);
-		let r: PredictionContext =  this.contextCache.join(a, b);
+		let r: PredictionContext =  this._contextCache.join(a, b);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -342,7 +342,7 @@ export class TestGraphNodes {
 	@Test test_ax_by(): void {
 		let a: PredictionContext =  this.createSingleton(this.x(false), 1);
 		let b: PredictionContext =  this.createSingleton(this.y(false), 2);
-		let r: PredictionContext =  this.contextCache.join(a, b);
+		let r: PredictionContext =  this._contextCache.join(a, b);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -363,7 +363,7 @@ export class TestGraphNodes {
 		let x2: PredictionContext =  this.x(false);
 		let aa: PredictionContext =  this.a(false);
 		let b: PredictionContext =  this.createSingleton(x2, 2);
-		let r: PredictionContext =  this.contextCache.join(aa, b);
+		let r: PredictionContext =  this._contextCache.join(aa, b);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -382,7 +382,7 @@ export class TestGraphNodes {
 		let x2: PredictionContext =  this.x(true);
 		let aa: PredictionContext =  this.a(true);
 		let b: PredictionContext =  this.createSingleton(x2, 2);
-		let r: PredictionContext =  this.contextCache.join(aa, b);
+		let r: PredictionContext =  this._contextCache.join(aa, b);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -404,7 +404,7 @@ export class TestGraphNodes {
 		let f: PredictionContext =  this.createSingleton(x2, 6);
 		let a: PredictionContext =  this.createSingleton(e, 1);
 		let b: PredictionContext =  this.createSingleton(f, 2);
-		let r: PredictionContext =  this.contextCache.join(a, b);
+		let r: PredictionContext =  this._contextCache.join(a, b);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -428,7 +428,7 @@ export class TestGraphNodes {
 	@Test test_A$_A$_fullctx(): void {
 		let A1: PredictionContext =  this.array(PredictionContext.EMPTY_FULL);
 		let A2: PredictionContext =  this.array(PredictionContext.EMPTY_FULL);
-		let r: PredictionContext =  this.contextCache.join(A1, A2);
+		let r: PredictionContext =  this._contextCache.join(A1, A2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -444,7 +444,7 @@ export class TestGraphNodes {
 		let cc: PredictionContext =  this.c(false);
 		let A1: PredictionContext = this. array(aa, bb);
 		let A2: PredictionContext =  this.array(cc);
-		let r: PredictionContext =  this.contextCache.join(A1, A2);
+		let r: PredictionContext =  this._contextCache.join(A1, A2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -463,7 +463,7 @@ export class TestGraphNodes {
 		let a2: PredictionContext = this. a(false);
 		let A1: PredictionContext =  this.array(a1);
 		let A2: PredictionContext =  this.array(a2);
-		let r: PredictionContext =  this.contextCache.join(A1, A2);
+		let r: PredictionContext =  this._contextCache.join(A1, A2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -481,7 +481,7 @@ export class TestGraphNodes {
 		let cc: PredictionContext =  this.c(false);
 		let A1: PredictionContext =  this.array(aa);
 		let A2: PredictionContext =  this.array(bb, cc);
-		let r: PredictionContext =  this.contextCache.join(A1, A2);
+		let r: PredictionContext =  this._contextCache.join(A1, A2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -501,7 +501,7 @@ export class TestGraphNodes {
 		let cc: PredictionContext =  this.c(false);
 		let A1: PredictionContext =  this.array(aa, cc);
 		let A2: PredictionContext =  this.array(bb);
-		let r: PredictionContext =  this.contextCache.join(A1, A2);
+		let r: PredictionContext =  this._contextCache.join(A1, A2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -518,7 +518,7 @@ export class TestGraphNodes {
 	@Test test_Aab_Aa(): void { // a,b + a
 		let A1: PredictionContext = this. array(this.a(false), this.b(false));
 		let A2: PredictionContext = this. array(this.a(false));
-		let r: PredictionContext =  this.contextCache.join(A1, A2);
+		let r: PredictionContext =  this._contextCache.join(A1, A2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -534,7 +534,7 @@ export class TestGraphNodes {
 	@Test test_Aab_Ab(): void { // a,b + b
 		let A1: PredictionContext =  this.array(this.a(false), this.b(false));
 		let A2: PredictionContext =  this.array(this.b(false));
-		let r: PredictionContext =  this.contextCache.join(A1, A2);
+		let r: PredictionContext =  this._contextCache.join(A1, A2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -552,7 +552,7 @@ export class TestGraphNodes {
 		let b: PredictionContext =  this.createSingleton(this.y(false), 2);
 		let A1: PredictionContext =  this.array(a);
 		let A2: PredictionContext =  this.array(b);
-		let r: PredictionContext =  this.contextCache.join(A1, A2);
+		let r: PredictionContext =  this._contextCache.join(A1, A2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -574,7 +574,7 @@ export class TestGraphNodes {
 		let a2: PredictionContext =  this.createSingleton(this.y(false), 1);
 		let A1: PredictionContext =  this.array(a1);
 		let A2: PredictionContext =  this.array(a2);
-		let r: PredictionContext =  this.contextCache.join(A1, A2);
+		let r: PredictionContext =  this._contextCache.join(A1, A2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -594,7 +594,7 @@ export class TestGraphNodes {
 		let a2: PredictionContext =  this.createSingleton(this.y(false), 1);
 		let A1: PredictionContext =  this.array(a1, this.c(false));
 		let A2: PredictionContext =  this.array(a2, this.d(false));
-		let r: PredictionContext =  this.contextCache.join(A1, A2);
+		let r: PredictionContext =  this._contextCache.join(A1, A2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -618,7 +618,7 @@ export class TestGraphNodes {
 		let d: PredictionContext =  this.createSingleton(this.x(false), 4);
 		let A1: PredictionContext =  this.array(a, b);
 		let A2: PredictionContext =  this.array(c, d);
-		let r: PredictionContext =  this.contextCache.join(A1, A2);
+		let r: PredictionContext =  this._contextCache.join(A1, A2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -648,7 +648,7 @@ export class TestGraphNodes {
 		let d: PredictionContext =  this.createSingleton(this.x(false), 4);
 		let A1: PredictionContext =  this.array(a, b1);
 		let A2: PredictionContext =  this.array(b2, d);
-		let r: PredictionContext =  this.contextCache.join(A1, A2);
+		let r: PredictionContext =  this._contextCache.join(A1, A2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -675,7 +675,7 @@ export class TestGraphNodes {
 		let d: PredictionContext =  this.createSingleton(this.x(false), 4);
 		let A1: PredictionContext =  this.array(a, b1);
 		let A2: PredictionContext =  this.array(b2, d);
-		let r: PredictionContext =  this.contextCache.join(A1, A2);
+		let r: PredictionContext =  this._contextCache.join(A1, A2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -703,7 +703,7 @@ export class TestGraphNodes {
 		let d: PredictionContext =  this.createSingleton(this.u(false), 4);
 		let A1: PredictionContext =  this.array(a, b1);
 		let A2: PredictionContext =  this.array(b2, d);
-		let r: PredictionContext =  this.contextCache.join(A1, A2);
+		let r: PredictionContext =  this._contextCache.join(A1, A2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -728,7 +728,7 @@ export class TestGraphNodes {
 		let d: PredictionContext =  this.createSingleton(this.u(false), 4);
 		let A1: PredictionContext =  this.array(a, b);
 		let A2: PredictionContext =  this.array(c, d);
-		let r: PredictionContext =  this.contextCache.join(A1, A2);
+		let r: PredictionContext =  this._contextCache.join(A1, A2);
 		// console.log(toDOTString(r));
 		let expecting: string =
 			"digraph G {\n" +
@@ -784,14 +784,14 @@ y(fullContext: boolean): PredictionContext {
 }
 
 createSingleton(parent: PredictionContext, payload: number): PredictionContext {
-	let a: PredictionContext = this.contextCache.getChild(parent, payload);
+	let a: PredictionContext = this._contextCache.getChild(parent, payload);
 	return a;
 }
 
 array(...nodes: PredictionContext[]): PredictionContext {
 	let result: PredictionContext = nodes[0];
 	for (let i = 1; i < nodes.length; i++) {
-		result = this.contextCache.join(result, nodes[i]);
+		result = this._contextCache.join(result, nodes[i]);
 	}
 
 	return result;

--- a/test/tool/TestTokenStreamRewriter.ts
+++ b/test/tool/TestTokenStreamRewriter.ts
@@ -29,14 +29,14 @@ import { suite, test as Test, skip as Ignore } from 'mocha-typescript';
 @suite
 export class TestTokenStreamRewriter {
 
-	private createLexerInterpreter(input: string, lexerCtor: {new(stream: CharStream): Lexer}): LexerInterpreter {
+	private _createLexerInterpreter(input: string, lexerCtor: {new(stream: CharStream): Lexer}): LexerInterpreter {
 		let stream = new ANTLRInputStream(input);
 		let lexer = new lexerCtor(stream);
 		return new LexerInterpreter(lexer.grammarFileName, lexer.vocabulary, lexer.modeNames, lexer.ruleNames, lexer.atn, stream);
 	}
 
 	@Test testInsertBeforeIndex0(): void {
-		let lexEngine: LexerInterpreter =  this.createLexerInterpreter("abc", RewriterLexer1);
+		let lexEngine: LexerInterpreter =  this._createLexerInterpreter("abc", RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -48,7 +48,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testInsertAfterLastIndex(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -60,7 +60,7 @@ export class TestTokenStreamRewriter {
 
 	@Test test2InsertBeforeAfterMiddleIndex(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -73,7 +73,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testReplaceIndex0(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -85,7 +85,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testReplaceLastIndex(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -97,7 +97,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testReplaceMiddleIndex(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -111,7 +111,7 @@ export class TestTokenStreamRewriter {
 		// Tokens: 0123456789
 		// Input:  x = 3 * 0;
 		let input: string =  "x = 3 * 0;";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer2);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer2);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -140,7 +140,7 @@ export class TestTokenStreamRewriter {
 		// Tokens: 012345678901234567
 		// Input:  x = 3 * 0 + 2 * 0;
 		let input: string =  "x = 3 * 0 + 2 * 0;";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer3);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer3);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -186,7 +186,7 @@ export class TestTokenStreamRewriter {
 
 	@Test test2ReplaceMiddleIndex(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -199,7 +199,7 @@ export class TestTokenStreamRewriter {
 
 	@Test test2ReplaceMiddleIndex1InsertBefore(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -213,7 +213,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testReplaceThenDeleteMiddleIndex(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -226,7 +226,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testInsertInPriorReplace(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -251,7 +251,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testInsertThenReplaceSameIndex(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -266,7 +266,7 @@ export class TestTokenStreamRewriter {
 
 	@Test test2InsertMiddleIndex(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -279,7 +279,7 @@ export class TestTokenStreamRewriter {
 
 	@Test test2InsertThenReplaceIndex0(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -293,7 +293,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testReplaceThenInsertBeforeLastIndex(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -306,7 +306,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testInsertThenReplaceLastIndex(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -319,7 +319,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testReplaceThenInsertAfterLastIndex(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -332,7 +332,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testReplaceRangeThenInsertAtLeftEdge(): void {
 		let input: string =  "abcccba";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -345,7 +345,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testReplaceRangeThenInsertAtRightEdge(): void {
 		let input: string =  "abcccba";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -371,7 +371,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testReplaceRangeThenInsertAfterRightEdge(): void {
 		let input: string =  "abcccba";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -384,7 +384,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testReplaceAll(): void {
 		let input: string =  "abcccba";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -396,7 +396,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testReplaceSubsetThenFetch(): void {
 		let input: string =  "abcccba";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -408,7 +408,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testReplaceThenReplaceSuperset(): void {
 		let input: string =  "abcccba";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -435,7 +435,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testReplaceThenReplaceLowerIndexedSuperset(): void {
 		let input: string =  "abcccba";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -462,7 +462,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testReplaceSingleMiddleThenOverlappingSuperset(): void {
 		let input: string =  "abcba";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -475,7 +475,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testCombineInserts(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -488,7 +488,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testCombine3Inserts(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -502,7 +502,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testCombineInsertOnLeftWithReplace(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -517,7 +517,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testCombineInsertOnLeftWithDelete(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -534,7 +534,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testDisjointInserts(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -548,7 +548,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testOverlappingReplace(): void {
 		let input: string =  "abcc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -563,7 +563,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testOverlappingReplace2(): void {
 		let input: string =  "abcc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -590,7 +590,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testOverlappingReplace3(): void {
 		let input: string =  "abcc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -605,7 +605,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testOverlappingReplace4(): void {
 		let input: string =  "abcc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -620,7 +620,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testDropIdenticalReplace(): void {
 		let input: string =  "abcc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -635,7 +635,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testDropPrevCoveredInsert(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -650,7 +650,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testLeaveAloneDisjointInsert(): void {
 		let input: string =  "abcc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -663,7 +663,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testLeaveAloneDisjointInsert2(): void {
 		let input: string =  "abcc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -676,7 +676,7 @@ export class TestTokenStreamRewriter {
 
 	@Test testInsertBeforeTokenThenDeleteThatToken(): void {
 		let input: string =  "abc";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -691,7 +691,7 @@ export class TestTokenStreamRewriter {
 	@Test
 	testDistinguishBetweenInsertAfterAndInsertBeforeToPreserverOrder(): void {
 		let input: string =  "aa";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
@@ -707,7 +707,7 @@ export class TestTokenStreamRewriter {
 	@Test
 	testDistinguishBetweenInsertAfterAndInsertBeforeToPreserverOrder2(): void {
 		let input: string = "aa";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream = new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter = new TokenStreamRewriter(stream);
@@ -726,7 +726,7 @@ export class TestTokenStreamRewriter {
 	@Test
 	testPreservesOrderOfContiguousInserts(): void {
 		let input: string = "ab";
-		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let lexEngine: LexerInterpreter = this._createLexerInterpreter(input, RewriterLexer1);
 		let stream: CommonTokenStream = new CommonTokenStream(lexEngine);
 		stream.fill();
 		let tokens: TokenStreamRewriter = new TokenStreamRewriter(stream);

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
@@ -612,7 +612,7 @@ if ( <if(invert)><m.varName> \<= 0 || <else>!<endif>(<expr>) ) {
 	<if(m.labels)><m.labels:{l | <labelref(l)> = }><endif>this._errHandler.recoverInline(this);
 } else {
 	if (this._input.LA(1) === Token.EOF) {
-		this.matchedEOF = true;
+		this._matchedEOF = true;
 	}
 
 	this._errHandler.reportMatch(this);
@@ -857,7 +857,7 @@ _prevctx = _localctx;
 >>
 
 recRuleSetPrevCtx() ::= <<
-if ( this._parseListeners!=null ) this.triggerExitRuleEvent();
+if ( this._parseListeners!=null ) this._triggerExitRuleEvent();
 _prevctx = _localctx;
 >>
 

--- a/tool/test/org/antlr/v4/test/runtime/typescript/TypeScript.test.stg
+++ b/tool/test/org/antlr/v4/test/runtime/typescript/TypeScript.test.stg
@@ -469,12 +469,12 @@ export class LeafVisitor extends AbstractParseTreeVisitor\<string> implements <g
 	}
 
 	@Override
-	protected defaultResult(): string {
+	protected _defaultResult(): string {
 		return "";
 	}
 
 	@Override
-	protected aggregateResult(aggregate: string, nextResult: string): string {
+	protected _aggregateResult(aggregate: string, nextResult: string): string {
 		return aggregate + nextResult;
 	}
 }
@@ -490,12 +490,12 @@ export class LeafVisitor extends AbstractParseTreeVisitor\<string> implements <g
 	}
 
 	@Override
-	protected defaultResult(): string {
+	protected _defaultResult(): string {
 		return "";
 	}
 
 	@Override
-	protected aggregateResult(aggregate: string, nextResult: string): string {
+	protected _aggregateResult(aggregate: string, nextResult: string): string {
 		return aggregate + nextResult;
 	}
 }
@@ -511,12 +511,12 @@ export class LeafVisitor extends AbstractParseTreeVisitor\<string> implements <g
 	}
 
 	@Override
-	protected defaultResult(): string {
+	protected _defaultResult(): string {
 		return "";
 	}
 
 	@Override
-	protected shouldVisitNextChild(node: RuleNode, currentResult: string): boolean {
+	protected _shouldVisitNextChild(node: RuleNode, currentResult: string): boolean {
 		return currentResult.length === 0;
 	}
 }
@@ -532,12 +532,12 @@ export class LeafVisitor extends AbstractParseTreeVisitor\<string> implements <g
 	}
 
 	@Override
-	protected defaultResult(): string {
+	protected _defaultResult(): string {
 		return "default result";
 	}
 
 	@Override
-	protected shouldVisitNextChild(node: RuleNode, currentResult: string): boolean {
+	protected _shouldVisitNextChild(node: RuleNode, currentResult: string): boolean {
 		return false;
 	}
 }
@@ -582,12 +582,12 @@ export class LeafVisitor extends AbstractParseTreeVisitor\<number> implements <g
 	}
 
 	@Override
-	protected defaultResult(): never {
+	protected _defaultResult(): never {
 		throw new Error("Should not be reachable");
 	}
 
 	@Override
-	protected aggregateResult(aggregate: number, nextResult: number): never {
+	protected _aggregateResult(aggregate: number, nextResult: number): never {
 		throw new Error("Should not be reachable");
 	}
 }


### PR DESCRIPTION
This includes a significant number of minor changes for cleanup of long-pending issues.

Fixes: #53 by using `throw new Error(<string>)` rather than `throw <string>`
Fixes: #141 by adding a leading underscore to the names of private & protected members.

As far as the underscore convention goes, we are already partially done with that.  This code review is probably a good time to think through the consequences of following it completely, particularly for protected members that might be considered part of the API.    