### PR TITLE
Adds tryGetChild() support to RuleNode.

### DIFF
--- a/src/ParserRuleContext.ts
+++ b/src/ParserRuleContext.ts
@@ -205,17 +205,17 @@ export class ParserRuleContext extends RuleContext {
 		return result;
 	}
 
-	tryGetChild<T extends ParseTree>(i: number, ctxType: { new (...args: any[]): T; }): T | undefined {
+	tryGetChild<T extends ParseTree>(i: number, ctxType?: { new (...args: any[]): T; }): T | undefined {
 		if (!this.children || i < 0 || i >= this.children.length) {
 			return undefined;
 		}
 
 		let j: number = -1; // what node with ctxType have we found?
 		for (let o of this.children) {
-			if (o instanceof ctxType) {
+			if (!ctxType || o instanceof ctxType) {
 				j++;
 				if (j === i) {
-					return o;
+					return o as T;
 				}
 			}
 		}

--- a/src/RuleContext.ts
+++ b/src/RuleContext.ts
@@ -166,6 +166,11 @@ export class RuleContext extends RuleNode {
 	}
 
 	@Override
+	tryGetChild(i: number): ParseTree | undefined {
+		return undefined;
+	}
+
+	@Override
 	get childCount(): number {
 		return 0;
 	}

--- a/src/tree/RuleNode.ts
+++ b/src/tree/RuleNode.ts
@@ -17,7 +17,8 @@ export abstract class RuleNode implements ParseTree {
 	//@Override
 	abstract readonly parent: RuleNode | undefined;
 
-	abstract getChild(i: number): ParseTree;
+	abstract getChild(i: number ): ParseTree;
+	abstract tryGetChild(i: number ): ParseTree | undefined;
 
 	abstract accept<T>(visitor: ParseTreeVisitor<T>): T;
 


### PR DESCRIPTION
I think this completes workitem #128 by finishing up support for `tryGetChild()`.   

I'm not clear if it fully addresses the reason #261 got re-opened