### PR TITLE
Eliminate `children` from Tree, RuleNode, etc by making `Tree` extend `ArrayLike<Tree>`

### DIFF
--- a/src/tree/RuleNode.ts
+++ b/src/tree/RuleNode.ts
@@ -10,8 +10,9 @@ import { ParseTree } from "./ParseTree";
 import { ParseTreeVisitor } from "./ParseTreeVisitor";
 import { Parser } from "../Parser";
 import { Interval } from "../misc/Interval";
+import { TerminalNode } from "./TerminalNode";
 
-export abstract class RuleNode implements ParseTree {
+export abstract class RuleNode extends Array<RuleNode|TerminalNode> implements ParseTree {
 	abstract readonly ruleContext: RuleContext;
 
 	//@Override

--- a/src/tree/TerminalNode.ts
+++ b/src/tree/TerminalNode.ts
@@ -17,9 +17,15 @@ export class TerminalNode implements ParseTree {
 	_symbol: Token;
 	_parent: RuleNode | undefined;
 
-	constructor(symbol: Token) {
+	constructor(symbol: Token, parent?: RuleNode) {
+		this._parent = parent;
 		this._symbol = symbol;
 	}
+
+	// Dummy ArrayLike<ParseTree> implemetation
+
+	[n: number]: this;
+	length: number = 0;
 
 	@Override
 	getChild(i: number): never {

--- a/src/tree/Tree.ts
+++ b/src/tree/Tree.ts
@@ -8,7 +8,7 @@
 /** The basic notion of a tree has a parent, a payload, and a list of children.
  *  It is the most abstract interface for all the trees used by ANTLR.
  */
-export interface Tree {
+export interface Tree extends ArrayLike<Tree> {
 	/** The parent of this node. If the return value is `undefined`, then this
 	 *  node is the root of the tree.
 	 */

--- a/src/tree/Trees.ts
+++ b/src/tree/Trees.ts
@@ -225,7 +225,7 @@ export class Trees {
 			if (child instanceof ParserRuleContext && (range.b < startIndex || range.a > stopIndex)) {
 				if (Trees.isAncestorOf(child, root)) { // replace only if subtree doesn't have displayed root
 					let abbrev: CommonToken = new CommonToken(Token.INVALID_TYPE, "...");
-					t.children![i] = new TerminalNode(abbrev); // HACK access to private
+					t[i] = new TerminalNode(abbrev); // HACK access to private
 				}
 			}
 		}


### PR DESCRIPTION
This is a discussion-only prototype for simplifying `Tree` protocol to be `ArrayLike`, so that `.length` and assess via `[n]` and iteration are uncomplicated.

- `RuleNode` extends `Array<RuleNode|TerminalNode>`
- `TerminalNode` gets a dummy implementation of `ArrayLike` without actually being an array.

Includes fixup within the runtime as needed to eliminate references to `children` as a property, but does not (yet) attempt to eliminate `.getChild()` etc.  