### PR TITLE
Suppress the RuleVersion decorator for now

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
@@ -33,7 +33,7 @@ import { ParseTreeListener } from '<basePath()>/tree/ParseTreeListener';
 import { ParseTreeVisitor } from '<basePath()>/tree/ParseTreeVisitor';
 import { RecognitionException } from '<basePath()>/RecognitionException';
 import { RuleContext } from '<basePath()>/RuleContext';
-import { RuleVersion } from '<basePath()>/RuleVersion';
+//import { RuleVersion } from '<basePath()>/RuleVersion';
 import { TerminalNode } from '<basePath()>/tree/TerminalNode';
 import { Token } from '<basePath()>/Token';
 import { TokenStream } from '<basePath()>/TokenStream';
@@ -272,7 +272,7 @@ case <index>:
 >>
 
 RuleFunction(currentRule,args,code,locals,ruleCtx,altLabelCtxs,namedActions,finallyAction,postamble,exceptions) ::= <<
-@RuleVersion(<namedActions.version; null="0">)
+//@RuleVersion(<namedActions.version; null="0">)
 <if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else>public <endif><currentRule.name>(<args; separator=",">): <currentRule.ctxType> {
 	let _localctx: <currentRule.ctxType> = new <currentRule.ctxType>(this._ctx, this.state<currentRule.args:{a | , <a.name>}>);
 	this.enterRule(_localctx, <currentRule.startState>, <parser.name>.RULE_<currentRule.name>);
@@ -381,7 +381,7 @@ LeftRecursiveRuleFunction(currentRule,args,code,locals,ruleCtx,altLabelCtxs,
 
 <if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else>public <endif><currentRule.name>(<args; separator=", ">): <currentRule.ctxType>;
 <if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else>public <endif><currentRule.name>(<args; separator=", "><if(args)>, <endif>_p: number): <currentRule.ctxType>;
-@RuleVersion(<namedActions.version; null="0">)
+//@RuleVersion(<namedActions.version; null="0">)
 <if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else>public <endif><currentRule.name>(<args; separator=", "><if(args)>, <endif>_p?: number): <currentRule.ctxType> {
 	if (_p === undefined) {
 		_p = 0;


### PR DESCRIPTION
This feature is only partially implemented in the TypeScript target, and the language feature is still experimental. Comment out the generated code related to the attribute for now.

Fixes #331