### PR TITLE
Internal collection APIs cleanup

### DIFF
--- a/src/atn/ATNConfigSet.ts
+++ b/src/atn/ATNConfigSet.ts
@@ -402,18 +402,6 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 	}
 
 	@Override
-	public retainAll(c: Iterable<any>): boolean {
-		this.ensureWritable();
-		throw new Error("Not supported yet.");
-	}
-
-	@Override
-	public removeAll(c: Iterable<any>): boolean {
-		this.ensureWritable();
-		throw new Error("Not supported yet.");
-	}
-
-	@Override
 	public clear(): void {
 		this.ensureWritable();
 		if (!this.mergedConfigs || !this.unmerged) {
@@ -554,41 +542,6 @@ export class ATNConfigSet implements JavaSet<ATNConfig> {
 
 	public get(index: number): ATNConfig {
 		return this.configs[index];
-	}
-
-	// @Override
-	// remove(o: any): boolean {
-	// 	this.ensureWritable();
-
-	// 	throw new Error("Not supported yet.");
-	// }
-
-	public remove(o: any): boolean;
-	public remove(index: number): void;
-	public remove(indexOrItem: number | any): boolean | void {
-		this.ensureWritable();
-		if (!this.mergedConfigs || !this.unmerged) {
-			throw new Error("Covered by ensureWritable but duplicated here for strict null check limitation");
-		}
-
-		if (typeof indexOrItem !== "number") {
-			throw new Error("Not supported yet");
-		}
-
-		let index = indexOrItem;
-		let config: ATNConfig = this.configs[index];
-		this.configs.splice(index, 1);
-		let key = this.getKey(config);
-		if (this.mergedConfigs.get(key) === config) {
-			this.mergedConfigs.remove(key);
-		} else {
-			for (let i = 0; i < this.unmerged.length; i++) {
-				if (this.unmerged[i] === config) {
-					this.unmerged.splice(i, 1);
-					return;
-				}
-			}
-		}
 	}
 
 	protected ensureWritable(): void {

--- a/src/misc/Array2DHashMap.ts
+++ b/src/misc/Array2DHashMap.ts
@@ -105,12 +105,6 @@ export class Array2DHashMap<K, V> implements JavaMap<K, V> {
 		}
 	}
 
-	public remove(key: K): V | undefined {
-		let value = this.get(key);
-		this.backingStore.remove({ key });
-		return value;
-	}
-
 	get size(): number {
 		return this.backingStore.size;
 	}
@@ -189,23 +183,6 @@ class EntrySet<K, V> implements JavaSet<JavaMap.Entry<K, V>> {
 		throw new Error("Not implemented");
 	}
 
-	public remove(o: any): boolean {
-		throw new Error("Not implemented");
-	}
-
-	public removeAll(collection: Iterable<any>): boolean {
-		let removedAny = false;
-		for (let key of collection) {
-			removedAny = this.remove(key) || removedAny;
-		}
-
-		return removedAny;
-	}
-
-	public retainAll(collection: Iterable<any>): boolean {
-		throw new Error("Not implemented");
-	}
-
 	get size(): number {
 		return this.backingStore.size;
 	}
@@ -271,23 +248,6 @@ class KeySet<K, V> implements JavaSet<K> {
 	}
 
 	public [Symbol.iterator](): IterableIterator<K> {
-		throw new Error("Not implemented");
-	}
-
-	public remove(o: any): boolean {
-		return this.backingStore.remove({ key: o });
-	}
-
-	public removeAll(collection: Iterable<any>): boolean {
-		let removedAny = false;
-		for (let key of collection) {
-			removedAny = this.remove(key) || removedAny;
-		}
-
-		return removedAny;
-	}
-
-	public retainAll(collection: Iterable<any>): boolean {
 		throw new Error("Not implemented");
 	}
 
@@ -365,23 +325,6 @@ class ValueCollection<K, V> implements JavaCollection<V> {
 		for (let bucket of this.backingStore) {
 			yield bucket.value!;
 		}
-	}
-
-	public remove(o: any): boolean {
-		throw new Error("Not implemented");
-	}
-
-	public removeAll(collection: Iterable<any>): boolean {
-		let removedAny = false;
-		for (let key of collection) {
-			removedAny = this.remove(key) || removedAny;
-		}
-
-		return removedAny;
-	}
-
-	public retainAll(collection: Iterable<any>): boolean {
-		throw new Error("Not implemented");
 	}
 
 	get size(): number {

--- a/src/misc/Array2DHashSet.ts
+++ b/src/misc/Array2DHashSet.ts
@@ -243,37 +243,6 @@ export class Array2DHashSet<T> implements JavaSet<T> {
 	}
 
 	@Override
-	public remove(o: any): boolean {
-		return this.removeFast(this.asElementType(o));
-	}
-
-	public removeFast(@Nullable obj: T): boolean {
-		if (obj == null) {
-			return false;
-		}
-
-		let b: number = this.getBucket(obj);
-		let bucket = this.buckets[b];
-		if (!bucket) {
-			// no bucket
-			return false;
-		}
-
-		for (let i = 0; i < bucket.length; i++) {
-			let e = bucket[i];
-			if (this.comparator.equals(e, obj)) {          // found it
-				// shift all elements to the right down one
-				bucket.copyWithin(i, i + 1);
-				bucket.length--;
-				this.n--;
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	@Override
 	public containsAll(collection: JavaCollection<T>): boolean {
 		if (collection instanceof Array2DHashSet) {
 			let s = collection as any as Array2DHashSet<T>;
@@ -311,56 +280,6 @@ export class Array2DHashSet<T> implements JavaSet<T> {
 				changed = true;
 			}
 		}
-		return changed;
-	}
-
-	@Override
-	public retainAll(c: JavaCollection<T>): boolean {
-		let newsize: number = 0;
-		for (let bucket of this.buckets) {
-			if (bucket == null) {
-				continue;
-			}
-
-			let i: number;
-			let j: number;
-			for (i = 0, j = 0; i < bucket.length; i++) {
-				if (bucket[i] == null) {
-					break;
-				}
-
-				if (!c.contains(bucket[i])) {
-					// removed
-					continue;
-				}
-
-				// keep
-				if (i !== j) {
-					bucket[j] = bucket[i];
-				}
-
-				j++;
-				newsize++;
-			}
-
-			newsize += j;
-			bucket.length = j;
-		}
-
-		let changed: boolean = newsize !== this.n;
-		this.n = newsize;
-		return changed;
-	}
-
-	@Override
-	public removeAll(c: Iterable<T>): boolean {
-		let changed = false;
-		for (let o of c) {
-			if (this.removeFast(this.asElementType(o))) {
-				changed = true;
-			}
-		}
-
 		return changed;
 	}
 

--- a/src/misc/Stubs.ts
+++ b/src/misc/Stubs.ts
@@ -14,18 +14,13 @@ export interface Comparable<T> {
 
 // This has been tweaked to fore implemenations to support either Java or JavaScript collections passed in...
 
-export interface JavaCollection<E> extends Iterable<E> {
+export interface JavaCollection<E> extends Iterable<E>, Equatable {
 	add(e: E): boolean;
 	addAll(collection: Iterable<E>): boolean;
 	clear(): void;
 	contains(o: any): boolean;                         // Shouldn't argument be restricted to E?
 	containsAll(collection: Iterable<any>): boolean; // Shouldn't argument be restricted to Collection<E>?
-	equals(o: any): boolean;
-	hashCode(): number;
 	readonly isEmpty: boolean;
-	remove(o: any): boolean;                        // Shouldn't argument be restricted to E?
-	removeAll(collection: Iterable<any>): boolean; // Shouldn't argument be restricted to Collection<E>?
-	retainAll(collection: Iterable<any>): boolean; // Shouldn't argument be restricted to Collection<E>?
 	readonly size: number;
 	toArray(): any[];                               // Shouldn't return type be restricted to E[]?
 	toArray(a: E[]): E[];
@@ -39,12 +34,7 @@ export interface JavaSet<E> extends JavaCollection<E> {
 	// clear(): void;
 	// contains(o:any): boolean;               // Shouldn't argument be restricted to E?
 	// containsAll(collection: Iterable<any>)  // Shouldn't argument be restricted to E?
-	// equals(o:any): boolean;
-	// hashCode(): number;
 	// readonly isEmpty: boolean;
-	// remove(o: any);                         // Shouldn't argument be restricted to E?
-	// removeAll(collection: Iterable<any>);   // Shouldn't argument be restricted to E?
-	// retainAll(collection: Iterable<any>);   // Shouldn't argument be restricted to E?
 	// readonly size: number;
 	// toArray(): any[];                       // Shouldn't return type be restricted to E?
 	// toArray(a: E[]): E[];
@@ -60,7 +50,6 @@ export interface JavaMap<K, V> extends Equatable {
 	keySet(): JavaSet<K>;
 	put(key: K, value: V): V | undefined;
 	putAll<K2 extends K, V2 extends V>(m: JavaMap<K2, V2>): void;
-	remove(key: K): V | undefined;
 	readonly size: number;
 	values(): JavaCollection<V>;
 }


### PR DESCRIPTION
* Remove unnecessary remove operations on custom collections
* Consolidate implementations of `toList` and `toArray`
* Remove unnecessary properties from `JavaMap<K, V>`