### PR TITLE
Fix failure to validate exception messages

### DIFF
--- a/test/tool/TestParseTreeMatcher.ts
+++ b/test/tool/TestParseTreeMatcher.ts
@@ -61,17 +61,17 @@ export class TestParseTreeMatcher {
 
 	@Test public testInvertedTags(): void {
 		let m: ParseTreePatternMatcher = this.getPatternMatcher(ParseTreeMatcherX1Lexer, ParseTreeMatcherX1Parser);
-		assert.throws(() => m.split(">expr<"), "tag delimiters out of order in pattern: >expr<");
+		assert.throws(() => m.split(">expr<"), /^Error: tag delimiters out of order in pattern: >expr<$/);
 	}
 
 	@Test public testUnclosedTag(): void {
 		let m: ParseTreePatternMatcher = this.getPatternMatcher(ParseTreeMatcherX1Lexer, ParseTreeMatcherX1Parser);
-		assert.throws(() => m.split("<expr hi mom"), "unterminated tag in pattern: <expr hi mom");
+		assert.throws(() => m.split("<expr hi mom"), /^Error: unterminated tag in pattern: <expr hi mom$/);
 	}
 
 	@Test public testExtraClose(): void {
 		let m: ParseTreePatternMatcher = this.getPatternMatcher(ParseTreeMatcherX1Lexer, ParseTreeMatcherX1Parser);
-		assert.throws(() => m.split("<expr> >"), "missing start tag in pattern: <expr> >");
+		assert.throws(() => m.split("<expr> >"), /^Error: missing start tag in pattern: <expr> >$/);
 	}
 
 	@Test public testTokenizingPattern(): void {

--- a/test/tool/TestXPath.ts
+++ b/test/tool/TestXPath.ts
@@ -87,48 +87,48 @@ export class TestXPath {
 
 	@Test public testWeirdChar(): void {
 		let path: string = "&";
-		let expected: string = "Invalid tokens or characters at index 0 in path '&'";
+		let expected: RegExp = /^RangeError: Invalid tokens or characters at index 0 in path '&' -- $/;
 
 		this.testError(SAMPLE_PROGRAM, path, expected, (parser) => parser.prog(), TestXPathLexer, TestXPathParser);
 	}
 
 	@Test public testWeirdChar2(): void {
 		let path: string = "//w&e/";
-		let expected: string = "Invalid tokens or characters at index 3 in path '//w&e/'";
+		let expected: RegExp = /^RangeError: Invalid tokens or characters at index 3 in path '\/\/w&e\/' -- $/;
 
 		this.testError(SAMPLE_PROGRAM, path, expected, (parser) => parser.prog(), TestXPathLexer, TestXPathParser);
 	}
 
 	@Test public testBadSyntax(): void {
 		let path: string = "///";
-		let expected: string = "/ at index 2 isn't a valid rule name";
+		let expected: RegExp = /^Error: \/ at index 2 isn't a valid rule name$/;
 
 		this.testError(SAMPLE_PROGRAM, path, expected, (parser) => parser.prog(), TestXPathLexer, TestXPathParser);
 	}
 
 	@Test public testMissingWordAtEnd(): void {
 		let path: string = "//";
-		let expected: string = "Missing path element at end of path";
+		let expected: RegExp = /^Error: Missing path element at end of path$/;
 
 		this.testError(SAMPLE_PROGRAM, path, expected, (parser) => parser.prog(), TestXPathLexer, TestXPathParser);
 	}
 
 	@Test public testBadTokenName(): void {
 		let path: string = "//Ick";
-		let expected: string = "Ick at index 2 isn't a valid token name";
+		let expected: RegExp = /^Error: Ick at index 2 isn't a valid token name$/;
 
 		this.testError(SAMPLE_PROGRAM, path, expected, (parser) => parser.prog(), TestXPathLexer, TestXPathParser);
 	}
 
 	@Test public testBadRuleName(): void {
 		let path: string = "/prog/ick";
-		let expected: string = "ick at index 6 isn't a valid rule name";
+		let expected: RegExp = /^Error: ick at index 6 isn't a valid rule name$/;
 
 		this.testError(SAMPLE_PROGRAM, path, expected, (parser) => parser.prog(), TestXPathLexer, TestXPathParser);
 	}
 
 	protected testError<TParser extends Parser>(
-		input: string, path: string, expected: string,
+		input: string, path: string, expected: RegExp,
 		startRule: (parser: TParser) => ParseTree,
 		lexerCtor: {new(stream: CharStream): Lexer},
 		parserCtor: {new(stream: TokenStream): TParser}): void {


### PR DESCRIPTION
The previous use of strings instead of regular expressions caused the assertion to treat the message as an additional output string should the test function fail to throw. Switching to RegExp causes the assertion to instead validate the error message itself.

See nodejs/node#19867