### PR TITLE
Avoid writing console.log test messages in color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -242,9 +242,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.2.tgz",
-      "integrity": "sha512-bjk1RIeZBCe/WukrFToIVegOf91Pebr8cXYBwLBIsfiGWVQ+ifwWsT59H3RxrWzWrzd1l/Amk1/ioY5Fq3/bpA==",
+      "version": "10.12.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.10.tgz",
+      "integrity": "sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w==",
       "dev": true
     },
     "@types/shelljs": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "homepage": "https://github.com/tunnelvisionlabs/antlr4ts#readme",
   "devDependencies": {
     "@types/mocha": "^5.2.0",
-    "@types/node": "^10.1.2",
+    "@types/node": "^10.12.10",
     "@types/source-map-support": "^0.4.0",
     "@types/std-mocks": "^1.0.0",
     "codecov": "^3.1.0",


### PR DESCRIPTION
Fixes test failures when the process is run in a terminal with color support.