### PR TITLE
Update to TypeScript 2.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "std-mocks": "^1.0.1",
     "tslint": "5.10.0",
     "typedoc": "^0.11.1",
-    "typescript": "^2.6.2"
+    "typescript": "^2.8.3"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
📝 The **package-lock.json** file already referenced TypeScript 2.8.3.