### PR TITLE
Dont't ignore filtering by types in function getTokens.

### DIFF
--- a/src/BufferedTokenStream.ts
+++ b/src/BufferedTokenStream.ts
@@ -308,10 +308,6 @@ export class BufferedTokenStream implements TokenStream {
 			throw new RangeError("start " + start + " or stop " + stop + " not in 0.." + (this.tokens.length - 1));
 		}
 
-		if (start === 0 && stop === this.tokens.length - 1) {
-			return this.tokens;
-		}
-
 		if (start > stop) {
 			return [];
 		}


### PR DESCRIPTION
As I understand, getTokens must return filtered tokens even though the full range of indices has been passed. Now the filtering is skipped.