### PR TITLE
Actually share reference to text in CommonToken.fromToken

### DIFF
--- a/src/CommonToken.ts
+++ b/src/CommonToken.ts
@@ -107,7 +107,7 @@ export class CommonToken implements WritableToken {
 		result._charPositionInLine = oldToken.charPositionInLine;
 
 		if (oldToken instanceof CommonToken) {
-			result._text = oldToken.text;
+			result._text = oldToken._text;
 			result.source = oldToken.source;
 		} else {
 			result._text = oldToken.text;


### PR DESCRIPTION
This looks like a java conversion error.

The doc comment above (and java version) attempt to share the string/reference if the fromToken is a CommonToken.

However, the field got underscored'd in the conversion to typescript, and it looks like only the LHS got updated.
The upshot is that the without this change, if oldToken is a CommonToken, it will retrieve and copy the text from the oldToken, not share it.
With this change, it will share the reference if possible.
