### PR TITLE
Eliminate overloads of CharStreams.fromString()

### DIFF
--- a/src/CharStreams.ts
+++ b/src/CharStreams.ts
@@ -233,23 +233,22 @@ export namespace CharStreams {
 	// }
 
 	/**
-	 * Creates a {@link CharStream} given a {@link String}.
-	 */
-	export function fromString(s: string): CodePointCharStream;
-
-	/**
-	 * Creates a {@link CharStream} given a {@link String} and the {@code sourceName}
+	 * Creates a {@link CharStream} given a {@link String} and the optional {@code sourceName}
 	 * from which it came.
 	 */
-	export function fromString(s: string, sourceName: string): CodePointCharStream;
-	export function fromString(s: string, sourceName?: string): CodePointCharStream {
+	export function fromString(
+		s: string,
+		sourceName?: string
+	): CodePointCharStream {
 		if (sourceName === undefined || sourceName.length === 0) {
 			sourceName = IntStream.UNKNOWN_SOURCE_NAME;
 		}
 
 		// Initial guess assumes no code points > U+FFFF: one code
 		// point for each code unit in the string
-		let codePointBufferBuilder: CodePointBuffer.Builder = CodePointBuffer.builder(s.length);
+		let codePointBufferBuilder: CodePointBuffer.Builder = CodePointBuffer.builder(
+			s.length
+		);
 
 		// TODO: CharBuffer.wrap(String) rightfully returns a read-only buffer
 		// which doesn't expose its array, so we make a copy.
@@ -259,7 +258,10 @@ export namespace CharStreams {
 		}
 
 		codePointBufferBuilder.append(cb);
-		return CodePointCharStream.fromBuffer(codePointBufferBuilder.build(), sourceName);
+		return CodePointCharStream.fromBuffer(
+			codePointBufferBuilder.build(),
+			sourceName
+		);
 	}
 
 	// export function bufferFromChannel(

--- a/test/tool/TestCharStreams.ts
+++ b/test/tool/TestCharStreams.ts
@@ -19,6 +19,15 @@ export class TestCharStreams {
 	}
 
 	@test
+	public fromStringSupportsOptionalName(): void {
+		let s: CharStream = CharStreams.fromString("hello", "embeddedString");
+		assert.strictEqual(5, s.size);
+		assert.strictEqual(0, s.index);
+		assert.strictEqual("hello", s.toString());
+		assert.strictEqual("embeddedString", s.sourceName);
+	}
+
+	@test
 	public fromSMPStringHasExpectedSize(): void {
 		let s: CharStream = CharStreams.fromString("hello 🌎");
 		assert.strictEqual(7, s.size);


### PR DESCRIPTION
The typescript handbooks says:  [Don’t write several overloads that differ only in trailing parameters](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#use-optional-parameters). 
  

added test case for source name