### PR TITLE
Fixes compile issues for typescript 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -389,9 +389,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.10.tgz",
-      "integrity": "sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w==",
+      "version": "10.17.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
+      "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
       "dev": true
     },
     "@types/source-map-support": {
@@ -2459,9 +2459,9 @@
       }
     },
     "typescript": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
-      "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "@deboxsoft/cpx": "^1.5.0",
     "@types/mocha": "^5.2.0",
-    "@types/node": "^10.12.10",
+    "@types/node": "^10.17.28",
     "@types/source-map-support": "^0.4.0",
     "@types/std-mocks": "^1.0.0",
     "codecov": "^3.6.5",
@@ -81,7 +81,7 @@
     "std-mocks": "^1.0.1",
     "tslint": "^5.11.0",
     "typedoc": "^0.15.2",
-    "typescript": "^2.8.3"
+    "typescript": "^4.0.2"
   },
   "dependencies": {}
 }

--- a/src/atn/ParserATNSimulator.ts
+++ b/src/atn/ParserATNSimulator.ts
@@ -493,6 +493,7 @@ export class ParserATNSimulator extends ATNSimulator {
 					}
 
 					assert(remainingOuterContext != null);
+					// tslint:disable-next-line:no-unnecessary-type-assertion
 					remainingOuterContext = (remainingOuterContext as ParserRuleContext).parent;
 					s = next;
 				}
@@ -995,6 +996,7 @@ export class ParserATNSimulator extends ATNSimulator {
 				}
 
 				assert(remainingGlobalContext != null);
+				// tslint:disable-next-line:no-unnecessary-type-assertion
 				remainingGlobalContext = (remainingGlobalContext as ParserRuleContext).parent;
 				s = next;
 			}

--- a/src/misc/Array2DHashSet.ts
+++ b/src/misc/Array2DHashSet.ts
@@ -22,7 +22,7 @@ import { MurmurHash } from "./MurmurHash";
 const INITAL_CAPACITY: number = 16; // must be power of 2
 const LOAD_FACTOR: number = 0.75;
 
-export class Array2DHashSet<T> implements JavaSet<T> {
+export class Array2DHashSet<T extends { toString: () => string }> implements JavaSet<T> {
 	@NotNull
 	protected comparator: EqualityComparator<T>;
 


### PR DESCRIPTION
This fixes my issues when compiling the generated code in typescript 4.

Older versions of typescript were converting (in the definition files) `get abc() {}` to `readonly abc` thus breaking when trying to overwrite from outside the code.

Fixes #485