### PR TITLE
Apply definite assignment assertion to TokenDecl and RuleContextDecl

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
@@ -705,10 +705,10 @@ SetNonLocalAttr(s, rhsChunks)	  ::=
 
 AddToLabelList(a) ::= "<ctx(a.label)>._<a.listName>.push(<labelref(a.label)>);"
 
-TokenDecl(t) ::= "_<t.name>: <TokenLabelType()>"
+TokenDecl(t) ::= "_<t.name>!: <TokenLabelType()>"
 TokenTypeDecl(t) ::= "let <t.name>: number;"
 TokenListDecl(t) ::= "_<t.name>: Token[] = []"
-RuleContextDecl(r) ::= "_<r.name>: <r.ctxName>"
+RuleContextDecl(r) ::= "_<r.name>!: <r.ctxName>"
 RuleContextListDecl(rdecl) ::= "_<rdecl.name>: <rdecl.ctxName>[] = []"
 
 ContextTokenGetterDecl(t)      ::=


### PR DESCRIPTION
This change mitigates #477 prior to the availability of an `optional` property on the model objects similar to `ContextRuleGetterDecl` and `ContextTokenGetterDecl`.