### PR TITLE
Fix lint warning in generated parser

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
@@ -860,7 +860,7 @@ _prevctx = _localctx;
 >>
 
 recRuleSetPrevCtx() ::= <<
-if (this._parseListeners != null) {
+if (this._parseListeners !== null) {
 	this.triggerExitRuleEvent();
 }
 _prevctx = _localctx;


### PR DESCRIPTION
This previously generated a lint warning for the eqeqeq rule.