### PR TITLE
adhere to order when reducing rewrite operations

### DIFF
--- a/src/TokenStreamRewriter.ts
+++ b/src/TokenStreamRewriter.ts
@@ -412,7 +412,7 @@ export class TokenStreamRewriter {
 			let rop: ReplaceOp = op;
 			// Wipe prior inserts within range
 			let inserts: InsertBeforeOp[] = this.getKindOfOps(rewrites, InsertBeforeOp, i);
-			for (let iop of inserts.filter(i => !(i instanceof InsertAfterOp))) {
+			for (let iop of inserts.filter((i) => !(i instanceof InsertAfterOp))) {
 				if ( iop.index === rop.index ) {
 					// E.g., insert before 2, delete 2..2; update replace
 					// text to include insert before, kill insert
@@ -424,7 +424,7 @@ export class TokenStreamRewriter {
 					rewrites[iop.instructionIndex] = undefined;
 				}
 			}
-			for (let iop of inserts.filter(i => i instanceof InsertAfterOp)) {
+			for (let iop of inserts.filter((i) => i instanceof InsertAfterOp)) {
 				if ( iop.index === rop.index ) {
 					// E.g., insert before 2, delete 2..2; update replace
 					// text to include insert before, kill insert

--- a/test/tool/TestTokenStreamRewriter.ts
+++ b/test/tool/TestTokenStreamRewriter.ts
@@ -761,4 +761,22 @@ export class TestTokenStreamRewriter {
 		let expecting: string =  "[object Object]0falseabc";
 		assert.strictEqual(result, expecting);
 	}
+
+	@Test
+	public testDistinguishBetweenInsertAfterAndInsertBeforeToPreserverOrderWhenReplacing(): void {
+		let input: string =  "aa";
+		let lexEngine: LexerInterpreter = this.createLexerInterpreter(input, RewriterLexer1);
+		let stream: CommonTokenStream =  new CommonTokenStream(lexEngine);
+		stream.fill();
+		let tokens: TokenStreamRewriter =  new TokenStreamRewriter(stream);
+		tokens.insertBefore(0, "<b>");
+		tokens.insertAfter(0, "</b>");
+		tokens.insertBefore(1, "<b>");
+		tokens.insertAfter(1, "</b>");
+		tokens.replaceSingle(0, "1");
+		tokens.replaceSingle(1, "2");
+		let result: string =  tokens.getText();
+		let expecting: string =  "<b>1</b><b>2</b>";
+		assert.strictEqual(result, expecting);
+	}
 }


### PR DESCRIPTION
TokenStreamRewriter now preserves order of InsertAfter and InsertBefore operations, when these reference an index with with a Replace operation.