### PR TITLE
Use optional method syntax for enter/exit/visit

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "prepare": "npm run buildtool && npm link antlr4ts-cli && npm run antlr4ts && npm run tsc && npm link target/src && npm run buildrts",
+    "prepare": "npm run buildtool && npm link antlr4ts-cli && npm run antlr4ts && npm run tsc && npm link ./target/src && npm run buildrts",
     "unlink": "npm unlink antlr4ts && npm unlink target/src && npm unlink antlr4ts-cli && npm run unlinkruntime && npm run unlinktool",
     "unlinkruntime": "cd target/src && npm unlink",
     "buildtool": "cd tool && npm link -force",

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/TypeScript/TypeScript.stg
@@ -82,7 +82,7 @@ export interface <file.grammarName>Listener extends ParseTreeListener {
 <endif>
  * @param ctx the parse tree
  */
-enter<lname; format="cap">?: (ctx: <lname; format="cap">Context) => void;
+enter<lname; format="cap">?(ctx: <lname; format="cap">Context): void;
 /**
 <if(file.listenerLabelRuleNames.(lname))>
  * Exit a parse tree produced by the `<lname>`
@@ -92,7 +92,7 @@ enter<lname; format="cap">?: (ctx: <lname; format="cap">Context) => void;
 <endif>
  * @param ctx the parse tree
  */
-exit<lname; format="cap">?: (ctx: <lname; format="cap">Context) => void;}; separator="\n">
+exit<lname; format="cap">?(ctx: <lname; format="cap">Context): void;}; separator="\n">
 }
 
 <namedActions.afterListener>
@@ -128,7 +128,7 @@ export interface <file.grammarName>Visitor\<Result> extends ParseTreeVisitor\<Re
  * @param ctx the parse tree
  * @return the visitor result
  */
-visit<lname; format="cap">?: (ctx: <lname; format="cap">Context) => Result;}; separator="\n">
+visit<lname; format="cap">?(ctx: <lname; format="cap">Context): Result;}; separator="\n">
 }
 
 <namedActions.afterVisitor>


### PR DESCRIPTION
# What does it do?

Generate `visitX?(ctx: XContext): Result` syntax rather than `visitX?: (ctx: XContext) => Result` for generated listener and visitor interface members.

# Why would we want this?

Usually, method-style implementations work fine on implementing classes even when the method is declared as a property in the interface.

```ts
// generated/LangVisitor.ts
...
visitFoo?: (ctx: FooContext) => Result;
...

// MyVisitor.ts
class MyVisitor implements LangVisitor<string> {
    // ok!
    visitFoo(ctx: FooContext): string {
        return 'foo';
    }
    ...
}
```

However, in some edge cases, it does not work so cleanly. Consider this construct in which `AbstractParseTreeVisitor` and `LangVisitor` are combined into `AbstractLangVisitor` (see https://github.com/microsoft/TypeScript/issues/22815#issuecomment-375766197 for context on the shenanigans going on here)

```ts
// MyVisitor.ts
abstract class AbstractLangVisitor<T> extends AbstractParseTreeVisitor<T> implements LangVisitor<T> {};
interface AbstractLangVisitor<T> extends LangVisitor<T> {};

class MyVisitor extends AbstractLangVisitor<string> {
    // error ts(2425): Class 'AbstractLangVisitor<string>' defines instance member property 'visitFoo',
    //                 but extended class 'MyVisitor' defines it as instance member function.
    visitFoo(ctx: FooContext): string {
        return 'foo';
    }
}
```

However, if we generate the member differently so that it looks like a method rather than like a property...

```ts
// generated/LangVisitor.ts
...
visitFoo?(ctx: FooContext): Result;
...

// MyVisitor.ts
abstract class AbstractLangVisitor<T> extends AbstractParseTreeVisitor<T> implements LangVisitor<T> {};
interface AbstractLangVisitor<T> extends LangVisitor<T> {};

class MyVisitor extends AbstractLangVisitor<string> {
    // ok! We can even use the new override annotation if we want!
    override visitFoo(ctx: FooContext): string {
        return 'foo';
    }
}
```

Importantly, this alternative form still works if you declare it as a property rather than a method.
```ts
class MyVisitor extends AbstractLangVisitor<string> {
    // ok!
    visitFoo = (ctx: FooContext): string => {
        return 'foo';
    };
}
```

## One other small benefit...

This alternative form also gives better autocomplete when you ask the editor to generate a stub.
```ts
// generated/LangVisitor.ts
visitFoo?: (ctx: FooContext) => Result;

// Autocomplete "visitFoo" generates
visitFoo?: (ctx: FooContext) => string;
```
```ts
// generated/LangVisitor.ts
visitFoo?(ctx: FooContext): Result;

// Autocomplete "visitFoo" generates
visitFoo(ctx: FooContext): string {
    
}
```

# Drawbacks

As far as I can tell this shouldn't break any existing code. However, I'm also not familiar with the precise semantics of matching members with interface definitions, so It's possible that there is some edge case where this fails that I haven't thought of.

Also, if someone actually prefers the old style of autocomplete, this could be slightly more annoying for them.